### PR TITLE
Add Android AIR-CARE map prototype

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,44 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.aircare'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.aircare'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName '1.0'
+    }
+
+    buildFeatures {
+        viewBinding true
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.2'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
+
+    implementation "com.google.android.gms:play-services-maps:19.2.0"
+    implementation "com.google.android.libraries.places:places:4.4.1"
+    implementation "com.squareup.okhttp3:okhttp:4.12.0"
+    implementation "com.google.code.gson:gson:2.11.0"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar">
+
+        <meta-data
+            android:name="com.google.android.geo.API_KEY"
+            android:value="YOUR_GOOGLE_MAPS_API_KEY" />
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/aircare/Geo.kt
+++ b/app/src/main/java/com/aircare/Geo.kt
@@ -1,0 +1,58 @@
+package com.aircare
+
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.IOException
+
+object Geo {
+    private val client = OkHttpClient()
+    private val gson = Gson()
+
+    fun reverseGeocode(lat: Double, lng: Double, apiKey: String, language: String = "ko"): String? {
+        val url = HttpUrl.Builder()
+            .scheme("https")
+            .host("maps.googleapis.com")
+            .addPathSegment("maps")
+            .addPathSegment("api")
+            .addPathSegment("geocode")
+            .addPathSegment("json")
+            .addQueryParameter("latlng", "$lat,$lng")
+            .addQueryParameter("language", language)
+            .addQueryParameter("key", apiKey)
+            .build()
+
+        val request = Request.Builder()
+            .url(url)
+            .get()
+            .build()
+
+        return try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    return null
+                }
+                val body = response.body?.string() ?: return null
+                val geocodeResponse = gson.fromJson(body, GeocodeResponse::class.java)
+                if (geocodeResponse.status == "OK" && geocodeResponse.results.isNotEmpty()) {
+                    geocodeResponse.results.first().formattedAddress
+                } else {
+                    null
+                }
+            }
+        } catch (exception: IOException) {
+            null
+        }
+    }
+
+    private data class GeocodeResponse(
+        @SerializedName("results") val results: List<GeocodeResult> = emptyList(),
+        @SerializedName("status") val status: String = ""
+    )
+
+    private data class GeocodeResult(
+        @SerializedName("formatted_address") val formattedAddress: String = ""
+    )
+}

--- a/app/src/main/java/com/aircare/MainActivity.kt
+++ b/app/src/main/java/com/aircare/MainActivity.kt
@@ -1,0 +1,192 @@
+package com.aircare
+
+import android.Manifest
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.widget.TextView
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.OnMapReadyCallback
+import com.google.android.gms.maps.SupportMapFragment
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.TileOverlayOptions
+import com.google.android.gms.maps.model.UrlTileProvider
+import com.google.android.material.bottomsheet.BottomSheetBehavior
+import com.google.android.material.button.MaterialButton
+import com.google.android.material.card.MaterialCardView
+import com.google.android.material.snackbar.Snackbar
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.net.MalformedURLException
+import java.net.URL
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCameraIdleListener {
+
+    private var googleMap: GoogleMap? = null
+    private lateinit var addressTextView: TextView
+    private lateinit var coordinatesTextView: TextView
+    private lateinit var updatedAtTextView: TextView
+    private lateinit var bottomSheetBehavior: BottomSheetBehavior<MaterialCardView>
+
+    private val locationPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                enableMyLocation()
+            } else {
+                showPermissionDeniedMessage()
+            }
+        }
+
+    private lateinit var autocompleteLauncher: ActivityResultLauncher<android.content.Intent>
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        PlacesSearch.initialize(application)
+
+        addressTextView = findViewById(R.id.text_address)
+        coordinatesTextView = findViewById(R.id.text_coordinates)
+        updatedAtTextView = findViewById(R.id.text_updated_at)
+
+        val bottomSheetCard: MaterialCardView = findViewById(R.id.bottom_sheet_container)
+        bottomSheetBehavior = BottomSheetBehavior.from(bottomSheetCard)
+        bottomSheetBehavior.state = BottomSheetBehavior.STATE_COLLAPSED
+
+        val seoul = LatLng(37.5665, 126.9780)
+        coordinatesTextView.text = String.format(
+            Locale.KOREA,
+            getString(R.string.coordinates_placeholder),
+            seoul.latitude,
+            seoul.longitude
+        )
+        updatedAtTextView.text = String.format(
+            getString(R.string.updated_placeholder),
+            SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.KOREA).format(Date())
+        )
+
+        autocompleteLauncher =
+            registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+                if (result.resultCode == Activity.RESULT_OK) {
+                    val place = PlacesSearch.parseResult(result.data)
+                    place?.let { latLng ->
+                        googleMap?.animateCamera(CameraUpdateFactory.newLatLngZoom(latLng, 13f))
+                    }
+                }
+            }
+
+        findViewById<MaterialButton>(R.id.button_search).setOnClickListener {
+            PlacesSearch.launchAutocomplete(this, autocompleteLauncher)
+        }
+
+        val mapFragment = supportFragmentManager
+            .findFragmentById(R.id.map_fragment) as SupportMapFragment
+        mapFragment.getMapAsync(this)
+
+        requestLocationPermission()
+    }
+
+    override fun onMapReady(map: GoogleMap) {
+        googleMap = map
+        val seoul = LatLng(37.5665, 126.9780)
+        map.moveCamera(CameraUpdateFactory.newLatLngZoom(seoul, 11f))
+        map.uiSettings.isMyLocationButtonEnabled = true
+        map.uiSettings.isZoomControlsEnabled = true
+
+        addHeatmapOverlay(map)
+
+        map.setOnCameraIdleListener(this)
+        enableMyLocation()
+    }
+
+    override fun onCameraIdle() {
+        val map = googleMap ?: return
+        val target = map.cameraPosition.target
+        coordinatesTextView.text = String.format(
+            Locale.KOREA,
+            getString(R.string.coordinates_placeholder),
+            target.latitude,
+            target.longitude
+        )
+        updatedAtTextView.text = String.format(
+            getString(R.string.updated_placeholder),
+            SimpleDateFormat("yyyy-MM-dd HH:mm", Locale.KOREA).format(Date())
+        )
+
+        lifecycleScope.launch(Dispatchers.IO) {
+            val address = Geo.reverseGeocode(
+                target.latitude,
+                target.longitude,
+                "YOUR_GOOGLE_MAPS_API_KEY"
+            )
+            withContext(Dispatchers.Main) {
+                if (!isFinishing && !isDestroyed) {
+                    addressTextView.text = address ?: getString(R.string.address_placeholder)
+                }
+            }
+        }
+    }
+
+    private fun addHeatmapOverlay(map: GoogleMap) {
+        val tileProvider = object : UrlTileProvider(256, 256) {
+            override fun getTileUrl(x: Int, y: Int, zoom: Int): URL? {
+                val url = String.format(
+                    Locale.US,
+                    "https://tile.googleapis.com/v1/airquality/heatmap/%d/%d/%d.png?key=%s",
+                    zoom,
+                    x,
+                    y,
+                    "YOUR_GOOGLE_MAPS_API_KEY"
+                )
+                return try {
+                    URL(url)
+                } catch (error: MalformedURLException) {
+                    null
+                }
+            }
+        }
+        map.addTileOverlay(
+            TileOverlayOptions()
+                .tileProvider(tileProvider)
+                .transparency(0.35f)
+        )
+    }
+
+    private fun enableMyLocation() {
+        val map = googleMap ?: return
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            map.isMyLocationEnabled = true
+        }
+    }
+
+    private fun requestLocationPermission() {
+        if (ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.ACCESS_FINE_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        ) {
+            enableMyLocation()
+        } else {
+            locationPermissionLauncher.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
+
+    private fun showPermissionDeniedMessage() {
+        val rootView = findViewById<MaterialCardView>(R.id.bottom_sheet_container)
+        Snackbar.make(rootView, R.string.address_placeholder, Snackbar.LENGTH_SHORT).show()
+    }
+}

--- a/app/src/main/java/com/aircare/PlacesSearch.kt
+++ b/app/src/main/java/com/aircare/PlacesSearch.kt
@@ -1,0 +1,42 @@
+package com.aircare
+
+import android.app.Activity
+import android.app.Application
+import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
+import com.google.android.gms.maps.model.LatLng
+import com.google.android.libraries.places.api.Places
+import com.google.android.libraries.places.api.model.Place
+import com.google.android.libraries.places.api.model.autocomplete.AutocompleteSessionToken
+import com.google.android.libraries.places.widget.Autocomplete
+import com.google.android.libraries.places.widget.model.AutocompleteActivityMode
+
+object PlacesSearch {
+    fun initialize(application: Application) {
+        if (!Places.isInitialized()) {
+            Places.initializeWithNewPlacesApiEnabled(
+                application.applicationContext,
+                "YOUR_GOOGLE_MAPS_API_KEY"
+            )
+        }
+    }
+
+    fun launchAutocomplete(activity: Activity, launcher: ActivityResultLauncher<Intent>) {
+        val fields = listOf(
+            Place.Field.ID,
+            Place.Field.NAME,
+            Place.Field.ADDRESS,
+            Place.Field.LAT_LNG
+        )
+        val intent = Autocomplete.IntentBuilder(AutocompleteActivityMode.FULLSCREEN, fields)
+            .setSessionToken(AutocompleteSessionToken.newInstance())
+            .build(activity)
+        launcher.launch(intent)
+    }
+
+    fun parseResult(data: Intent?): LatLng? {
+        if (data == null) return null
+        val place = Autocomplete.getPlaceFromIntent(data)
+        return place.latLng
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <FrameLayout
+        android:id="@+id/search_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:layout_gravity="top">
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/button_search"
+            style="@style/Widget.MaterialComponents.Button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="end"
+            android:text="@string/search_places"
+            app:cornerRadius="20dp"
+            app:icon="@android:drawable/ic_menu_search"
+            app:iconGravity="textStart"
+            app:iconPadding="8dp"
+            app:iconTint="@android:color/white" />
+    </FrameLayout>
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/map_fragment"
+        android:name="com.google.android.gms.maps.SupportMapFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/bottom_sheet_container"
+        style="@style/Widget.MaterialComponents.CardView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom"
+        android:layout_margin="16dp"
+        app:cardCornerRadius="24dp"
+        app:cardElevation="8dp"
+        app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="20dp">
+
+            <TextView
+                android:id="@+id/text_address"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/address_placeholder"
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Headline6"
+                android:textColor="@android:color/black" />
+
+            <TextView
+                android:id="@+id/text_coordinates"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text=""
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Body1" />
+
+            <TextView
+                android:id="@+id/text_updated_at"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text=""
+                android:textAppearance="@style/TextAppearance.MaterialComponents.Caption" />
+        </LinearLayout>
+    </com.google.android.material.card.MaterialCardView>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">AIR-CARE</string>
+    <string name="search_places">장소 검색</string>
+    <string name="address_placeholder">주소를 불러오는 중...</string>
+    <string name="coordinates_placeholder">위도: %.5f, 경도: %.5f</string>
+    <string name="updated_placeholder">업데이트: %s</string>
+</resources>


### PR DESCRIPTION
## Summary
- configure the Android application module with required dependencies for maps, places, networking, and coroutines
- implement the main activity with Google Maps, UAQI heatmap overlay, reverse geocoding, and Places autocomplete integration
- add manifest, layout, and string resources for map display and bottom sheet location details

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d92a6c32d48328bf3cefa2891cbd2a