### PR TITLE
Make Android app load Google API key from local properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+local.properties
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -18,3 +18,19 @@ View your app in AI Studio: https://ai.studio/apps/drive/127IEIc4eg4TQB7G3pPbMCI
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Android API keys
+
+If you plan to open the native Android project (`app/`), create or update `local.properties` in the project root with the line below:
+
+```
+GOOGLE_MAPS_API_KEY=your-android-key
+```
+
+The Gradle build reads this property and propagates it to:
+
+- `AndroidManifest.xml` for the Maps SDK meta-data entry.
+- `MainActivity.kt` for reverse geocoding and air-quality tile requests.
+- `PlacesSearch.kt` for Places SDK initialization.
+
+This keeps the key out of source control (the file is ignored by Git) and ensures every Maps-related feature shares the same value.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,7 +1,19 @@
+import java.util.Properties
+
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
 }
+
+def localProperties = new Properties()
+def localPropertiesFile = rootProject.file("local.properties")
+if (localPropertiesFile.exists()) {
+    localPropertiesFile.withReader('UTF-8') { reader ->
+        localProperties.load(reader)
+    }
+}
+
+def googleMapsApiKey = localProperties.getProperty('GOOGLE_MAPS_API_KEY') ?: ""
 
 android {
     namespace 'com.aircare'
@@ -13,6 +25,10 @@ android {
         targetSdk 34
         versionCode 1
         versionName '1.0'
+
+        buildConfigField 'String', 'GOOGLE_MAPS_API_KEY', "\"${googleMapsApiKey}\""
+        resValue 'string', 'google_maps_api_key', googleMapsApiKey
+        manifestPlaceholders = [GOOGLE_MAPS_API_KEY: googleMapsApiKey]
     }
 
     buildFeatures {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"
-            android:value="YOUR_GOOGLE_MAPS_API_KEY" />
+            android:value="${GOOGLE_MAPS_API_KEY}" />
 
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/aircare/MainActivity.kt
+++ b/app/src/main/java/com/aircare/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
+import com.aircare.BuildConfig
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.GoogleMap
 import com.google.android.gms.maps.OnMapReadyCallback
@@ -124,10 +125,20 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
         )
 
         lifecycleScope.launch(Dispatchers.IO) {
+            val apiKey = BuildConfig.GOOGLE_MAPS_API_KEY
+            if (apiKey.isBlank()) {
+                withContext(Dispatchers.Main) {
+                    if (!isFinishing && !isDestroyed) {
+                        addressTextView.text = getString(R.string.address_placeholder)
+                    }
+                }
+                return@launch
+            }
+
             val address = Geo.reverseGeocode(
                 target.latitude,
                 target.longitude,
-                "YOUR_GOOGLE_MAPS_API_KEY"
+                apiKey
             )
             withContext(Dispatchers.Main) {
                 if (!isFinishing && !isDestroyed) {
@@ -138,6 +149,11 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
     }
 
     private fun addHeatmapOverlay(map: GoogleMap) {
+        val apiKey = BuildConfig.GOOGLE_MAPS_API_KEY
+        if (apiKey.isBlank()) {
+            return
+        }
+
         val tileProvider = object : UrlTileProvider(256, 256) {
             override fun getTileUrl(x: Int, y: Int, zoom: Int): URL? {
                 val url = String.format(
@@ -146,7 +162,7 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
                     zoom,
                     x,
                     y,
-                    "YOUR_GOOGLE_MAPS_API_KEY"
+                    apiKey
                 )
                 return try {
                     URL(url)

--- a/app/src/main/java/com/aircare/PlacesSearch.kt
+++ b/app/src/main/java/com/aircare/PlacesSearch.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.app.Application
 import android.content.Intent
 import androidx.activity.result.ActivityResultLauncher
+import com.aircare.BuildConfig
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.libraries.places.api.Places
 import com.google.android.libraries.places.api.model.Place
@@ -14,9 +15,14 @@ import com.google.android.libraries.places.widget.model.AutocompleteActivityMode
 object PlacesSearch {
     fun initialize(application: Application) {
         if (!Places.isInitialized()) {
+            val apiKey = BuildConfig.GOOGLE_MAPS_API_KEY
+            if (apiKey.isBlank()) {
+                return
+            }
+
             Places.initializeWithNewPlacesApiEnabled(
                 application.applicationContext,
-                "YOUR_GOOGLE_MAPS_API_KEY"
+                apiKey
             )
         }
     }


### PR DESCRIPTION
## Summary
- load the Google Maps platform key from `local.properties` during the Android build
- propagate the key to the manifest and Kotlin sources instead of hard-coding the placeholder
- document the new setup and ignore `local.properties` in version control

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d93a033f60832899c24de63a23c7a9