### PR TITLE
Adjust header location name for coordinate selections

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -80,7 +80,11 @@ const App: React.FC = () => {
 
   return (
     <MainScreen
-      locationName={rawAirData?.locationName || locationSelection.city || '현재 위치'}
+      locationName={
+        locationSelection.city
+          ? rawAirData?.locationName || locationSelection.city
+          : '현재 위치'
+      }
       coordinates={locationSelection.coordinates || null}
       signalData={signalData}
       isLoading={isLoading}


### PR DESCRIPTION
## Summary
- ensure the main screen header uses the manually entered city name when present
- fall back to the "현재 위치" label when only coordinates were selected so GPS-based selections read correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d955e465908328a277b33577f04110