### PR TITLE
Add permission denied message

### DIFF
--- a/app/src/main/java/com/aircare/MainActivity.kt
+++ b/app/src/main/java/com/aircare/MainActivity.kt
@@ -203,6 +203,6 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
 
     private fun showPermissionDeniedMessage() {
         val rootView = findViewById<MaterialCardView>(R.id.bottom_sheet_container)
-        Snackbar.make(rootView, R.string.address_placeholder, Snackbar.LENGTH_SHORT).show()
+        Snackbar.make(rootView, R.string.permission_denied_message, Snackbar.LENGTH_SHORT).show()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,4 +5,5 @@
     <string name="address_placeholder">주소를 불러오는 중...</string>
     <string name="coordinates_placeholder">위도: %.5f, 경도: %.5f</string>
     <string name="updated_placeholder">업데이트: %s</string>
+    <string name="permission_denied_message">위치 권한이 필요합니다.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a dedicated permission denied string resource for location requests
- update the Snackbar in `MainActivity` to use the new resource when permissions are denied

## Testing
- not run (not supported in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9593216e08328921fc60a0322bf14