### PR TITLE
Replace search button with top app bar search menu

### DIFF
--- a/app/src/main/java/com/aircare/MainActivity.kt
+++ b/app/src/main/java/com/aircare/MainActivity.kt
@@ -9,6 +9,8 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
 import com.aircare.BuildConfig
 import com.google.android.gms.maps.CameraUpdateFactory
@@ -19,7 +21,7 @@ import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.TileOverlayOptions
 import com.google.android.gms.maps.model.UrlTileProvider
 import com.google.android.material.bottomsheet.BottomSheetBehavior
-import com.google.android.material.button.MaterialButton
+import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.card.MaterialCardView
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Dispatchers
@@ -86,9 +88,27 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
                 }
             }
 
-        findViewById<MaterialButton>(R.id.button_search).setOnClickListener {
-            PlacesSearch.launchAutocomplete(this, autocompleteLauncher)
+        val toolbar: MaterialToolbar = findViewById(R.id.top_app_bar)
+        toolbar.setOnMenuItemClickListener { menuItem ->
+            if (menuItem.itemId == R.id.action_search) {
+                PlacesSearch.launchAutocomplete(this, autocompleteLauncher)
+                true
+            } else {
+                false
+            }
         }
+
+        ViewCompat.setOnApplyWindowInsetsListener(toolbar) { view, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.statusBars())
+            view.setPadding(
+                view.paddingLeft,
+                insets.top,
+                view.paddingRight,
+                view.paddingBottom
+            )
+            windowInsets
+        }
+        ViewCompat.requestApplyInsets(toolbar)
 
         val mapFragment = supportFragmentManager
             .findFragmentById(R.id.map_fragment) as SupportMapFragment

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -6,26 +6,21 @@
     android:layout_height="match_parent"
     tools:context=".MainActivity">
 
-    <FrameLayout
-        android:id="@+id/search_container"
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:layout_gravity="top">
+        android:layout_height="wrap_content">
 
-        <com.google.android.material.button.MaterialButton
-            android:id="@+id/button_search"
-            style="@style/Widget.MaterialComponents.Button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="end"
-            android:text="@string/search_places"
-            app:cornerRadius="20dp"
-            app:icon="@android:drawable/ic_menu_search"
-            app:iconGravity="textStart"
-            app:iconPadding="8dp"
-            app:iconTint="@android:color/white" />
-    </FrameLayout>
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/top_app_bar"
+            style="@style/Widget.MaterialComponents.Toolbar.Primary"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="?attr/colorSurface"
+            app:layout_scrollFlags="scroll|enterAlways"
+            app:menu="@menu/menu_top_app_bar"
+            app:title="@string/app_name"
+            app:titleCentered="true" />
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/map_fragment"

--- a/app/src/main/res/menu/menu_top_app_bar.xml
+++ b/app/src/main/res/menu/menu_top_app_bar.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_search"
+        android:icon="@android:drawable/ic_menu_search"
+        android:title="@string/search_places"
+        app:showAsAction="ifRoom" />
+</menu>


### PR DESCRIPTION
## Summary
- replace the floating search button with a Material toolbar anchored at the top of the coordinator layout
- add a search menu item to the toolbar and reuse the autocomplete launcher when it is tapped
- handle status bar insets on the toolbar so it stays clear of system UI on fullscreen devices

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9593159a48328954504e2d37bc9fb