### PR TITLE
Update permission denial messaging

### DIFF
--- a/app/src/main/java/com/aircare/MainActivity.kt
+++ b/app/src/main/java/com/aircare/MainActivity.kt
@@ -261,7 +261,7 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
 
     private fun showPermissionDeniedMessage() {
         val rootView = binding.bottomSheetContainer
-        Snackbar.make(rootView, R.string.location_permission_denied_message, Snackbar.LENGTH_SHORT).show()
+        Snackbar.make(rootView, R.string.permission_denied_message, Snackbar.LENGTH_SHORT).show()
     }
 
     private fun showLocationUnavailableMessage() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,5 +6,6 @@
     <string name="coordinates_placeholder">위도: %.5f, 경도: %.5f</string>
     <string name="updated_placeholder">업데이트: %s</string>
     <string name="location_permission_denied_message">위치 권한이 필요합니다.</string>
+    <string name="permission_denied_message">권한이 거부되었습니다. 설정에서 권한을 허용해주세요.</string>
     <string name="location_unavailable_message">현재 위치를 가져올 수 없습니다.</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a reusable permission denied string resource
- update MainActivity to show the new snackbar copy when permissions are denied

## Testing
- not run (not applicable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d95bd9876083288860a23b423bfc5f