### PR TITLE
Switch to nationwide default summary view

### DIFF
--- a/components/Loader.tsx
+++ b/components/Loader.tsx
@@ -4,7 +4,7 @@ const Loader: React.FC = () => {
   return (
     <div className="flex flex-col items-center justify-center gap-4">
       <div className="animate-spin rounded-full h-16 w-16 border-b-4 border-brand-blue"></div>
-      <p className="text-lg text-medium-text">주변 대기질 데이터를 가져오는 중...</p>
+      <p className="text-lg text-medium-text">대기질 데이터를 가져오는 중...</p>
     </div>
   );
 };

--- a/components/MainScreen.tsx
+++ b/components/MainScreen.tsx
@@ -1,15 +1,16 @@
 import React, { useMemo } from 'react';
-import type { SignalData, Coordinates } from '../types';
+import type { SignalData, Coordinates, RawAirData } from '../types';
 import SignalIcon from './SignalIcon';
-import Loader from './Loader';
 import ErrorDisplay from './ErrorDisplay';
 import Header from './Header';
 import { MaskIcon, VentilateIcon, HumidifyIcon } from './Icons';
 import MapView from './MapView';
+import NationwideOverview from './Onboarding';
 
 interface MainScreenProps {
   locationName: string;
   coordinates: Coordinates | null;
+  nationwideData: RawAirData | null;
   signalData: SignalData | null;
   isLoading: boolean;
   error: string | null;
@@ -20,6 +21,7 @@ interface MainScreenProps {
 const MainScreen: React.FC<MainScreenProps> = ({
   locationName,
   coordinates,
+  nationwideData,
   signalData,
   isLoading,
   error,
@@ -46,17 +48,26 @@ const MainScreen: React.FC<MainScreenProps> = ({
 
   const renderContent = () => {
     if (isLoading) {
-      return <Loader />;
+      return (
+        <p className="text-medium-text text-center text-base">
+          전국 데이터를 불러오는 중입니다...
+        </p>
+      );
     }
     if (error) {
-      return <ErrorDisplay message={error} lastUpdated={lastUpdated ? `마지막 성공 업데이트: ${timeAgo}`: ''} />;
+      return (
+        <ErrorDisplay
+          message={error}
+          lastUpdated={lastUpdated ? `마지막 성공 업데이트: ${timeAgo}` : ''}
+        />
+      );
     }
     if (signalData) {
       return (
         <div className="grid grid-cols-3 gap-4 sm:gap-8 w-full max-w-2xl">
-          <SignalIcon 
-            label="마스크" 
-            isOn={signalData.isMaskOn} 
+          <SignalIcon
+            label="마스크"
+            isOn={signalData.isMaskOn}
             icon={<MaskIcon />}
             onColor="bg-red-100 text-danger-red"
             offColor="bg-gray-100 text-medium-text"
@@ -81,13 +92,18 @@ const MainScreen: React.FC<MainScreenProps> = ({
         </div>
       );
     }
-    return null;
+    return (
+      <p className="text-medium-text text-center text-base">
+        전국 대기질 정보를 불러오면 신호가 표시됩니다.
+      </p>
+    );
   };
 
   return (
     <div className="min-h-screen w-full flex flex-col items-center p-4 sm:p-6 bg-light-bg">
       <Header locationName={locationName} onRefresh={onRefresh} />
       <main className="flex-grow flex flex-col items-center w-full gap-6 py-6">
+        <NationwideOverview data={nationwideData} isLoading={isLoading} error={error} />
         {coordinates && (
           <div className="w-full max-w-2xl">
             <h2 className="text-lg font-semibold text-dark-text mb-3">현재 위치</h2>

--- a/components/Onboarding.tsx
+++ b/components/Onboarding.tsx
@@ -1,109 +1,74 @@
-import React, { useState } from 'react';
+import React from 'react';
+import type { RawAirData } from '../types';
 import { LogoIcon } from './Icons';
-import type { LocationSelection } from '../types';
 
-interface OnboardingProps {
-  onSubmit: (location: LocationSelection) => void;
+interface NationwideOverviewProps {
+  data: RawAirData | null;
+  isLoading: boolean;
+  error: string | null;
 }
 
-const Onboarding: React.FC<OnboardingProps> = ({ onSubmit }) => {
-  const [location, setLocation] = useState('');
-  const [isRequestingLocation, setIsRequestingLocation] = useState(false);
-  const [geoError, setGeoError] = useState<string | null>(null);
-
-  const submitLocation = (selection: LocationSelection) => {
-    setGeoError(null);
-    onSubmit(selection);
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (location.trim()) {
-      submitLocation({ city: location.trim() });
-    }
-  };
-
-  const handleUseCurrentLocation = () => {
-    if (!('geolocation' in navigator)) {
-      setGeoError('현재 브라우저에서는 위치 정보를 사용할 수 없습니다.');
-      return;
+const NationwideOverview: React.FC<NationwideOverviewProps> = ({ data, isLoading, error }) => {
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <div className="flex flex-col items-center justify-center gap-3 py-8">
+          <div className="h-12 w-12 border-4 border-brand-blue border-t-transparent rounded-full animate-spin" aria-hidden />
+          <p className="text-base text-medium-text">전국 데이터를 불러오는 중...</p>
+        </div>
+      );
     }
 
-    setIsRequestingLocation(true);
-    setGeoError(null);
+    if (error) {
+      return <p className="text-base font-medium text-danger-red text-center">{error}</p>;
+    }
 
-    navigator.geolocation.getCurrentPosition(
-      (position) => {
-        setIsRequestingLocation(false);
-        submitLocation({
-          city: location.trim() || null,
-          coordinates: {
-            latitude: position.coords.latitude,
-            longitude: position.coords.longitude,
-          },
-        });
-      },
-      (error) => {
-        console.error(error);
-        setIsRequestingLocation(false);
-        setGeoError('현재 위치를 가져오는 데 실패했습니다. 위치 권한을 확인하고 다시 시도하세요.');
-      },
-      { enableHighAccuracy: true, timeout: 10000, maximumAge: 60000 }
-    );
+    if (data) {
+      return (
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          <div className="rounded-2xl bg-light-bg p-4 text-center">
+            <p className="text-sm text-medium-text">주요 지역</p>
+            <p className="text-2xl font-semibold text-dark-text">{data.locationName}</p>
+          </div>
+          <div className="rounded-2xl bg-light-bg p-4 text-center">
+            <p className="text-sm text-medium-text">미세먼지 (PM10)</p>
+            <p className="text-3xl font-bold text-dark-text">{Math.round(data.pm10)} ㎍/㎥</p>
+          </div>
+          <div className="rounded-2xl bg-light-bg p-4 text-center">
+            <p className="text-sm text-medium-text">초미세먼지 (PM2.5)</p>
+            <p className="text-3xl font-bold text-dark-text">{Math.round(data.pm25)} ㎍/㎥</p>
+          </div>
+          <div className="rounded-2xl bg-light-bg p-4 text-center sm:col-span-3 sm:max-w-md sm:mx-auto">
+            <p className="text-sm text-medium-text">상대 습도</p>
+            <p className="text-3xl font-bold text-dark-text">{Math.round(data.humidity)}%</p>
+          </div>
+        </div>
+      );
+    }
+
+    return <p className="text-base text-medium-text text-center">대기질 정보를 준비하고 있어요.</p>;
   };
 
   return (
-    <div className="min-h-screen w-full flex flex-col items-center justify-center bg-gray-50 p-4">
-      <div className="w-full max-w-md text-center">
-        <div className="flex justify-center items-center gap-4 mb-6">
-          <LogoIcon className="h-16 w-16 text-brand-blue" />
-          <h1 className="text-5xl font-bold text-dark-text">에어케어</h1>
-        </div>
-        <p className="text-medium-text text-lg mb-8">
-          내 주변 공기 상태를 위한 간단한 신호를 받아보세요.
-        </p>
-        <p className="text-dark-text font-medium mb-4">
-          시작하려면 도시 이름을 입력하거나 현재 위치를 사용하세요.
-        </p>
-        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-          <input
-            type="text"
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            placeholder="예: 서울특별시"
-            className="w-full px-4 py-3 text-lg border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-blue focus:outline-none transition"
-            aria-label="위치 입력"
-          />
-          <button
-            type="submit"
-            className="w-full bg-brand-blue text-white font-bold py-3 px-4 rounded-lg hover:bg-blue-600 transition-colors duration-300 disabled:bg-gray-400"
-            disabled={!location.trim()}
-          >
-            신호 받기
-          </button>
-          <div className="relative">
-            <button
-              type="button"
-              onClick={handleUseCurrentLocation}
-              className="w-full border border-brand-blue text-brand-blue font-semibold py-3 px-4 rounded-lg hover:bg-blue-50 transition-colors duration-300 disabled:bg-gray-200 disabled:text-gray-500"
-              disabled={isRequestingLocation}
-            >
-              {isRequestingLocation ? '현재 위치 확인 중...' : '현재 위치 사용'}
-            </button>
-            {isRequestingLocation && (
-              <span className="absolute inset-y-0 right-4 flex items-center text-sm text-medium-text">
-                허용을 선택해주세요
-              </span>
-            )}
+    <section className="w-full max-w-4xl mx-auto bg-white rounded-3xl shadow-md p-6 sm:p-10">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+        <div className="flex items-center gap-4">
+          <LogoIcon className="h-12 w-12 text-brand-blue" />
+          <div>
+            <h2 className="text-2xl sm:text-3xl font-bold text-dark-text">대한민국 대기질 한눈에 보기</h2>
+            <p className="text-medium-text text-base sm:text-lg">
+              전국 주요 지역의 대기질을 요약해 실내 생활 신호를 안내해드려요.
+            </p>
           </div>
-        </form>
-        {geoError && <p className="text-sm text-danger-red mt-4">{geoError}</p>}
-        <p className="text-xs text-gray-400 mt-8">
-          에어케어는 현재 위치의 정확한 대기 정보를 제공하기 위해 위치 정보가 필요합니다. 이 정보는 데이터 조회에만 사용되며 절대 저장되지 않습니다.
-        </p>
+        </div>
+        <div className="text-sm text-medium-text sm:text-right">
+          <p>실시간 데이터를 기반으로 신호가 구성돼요.</p>
+          <p>변화가 느껴지면 새로고침해 최신 정보를 확인하세요.</p>
+        </div>
       </div>
-    </div>
+      {renderContent()}
+    </section>
   );
 };
 
-export default Onboarding;
+export default NationwideOverview;


### PR DESCRIPTION
## Summary
- initialize the app with a nationwide air-quality request and show the main screen immediately
- replace the onboarding search form with a nationwide overview card surfaced on the main screen
- update the main screen layout and loader copy to support global loading/error states for the summary data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da2494d7208328b04524ca867c1aa7