### PR TITLE
Add geolocation controls and dynamic map behavior

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import MainScreen from './components/MainScreen';
 import { getAirQualityData } from './services/geminiService';
-import type { RawAirData, SignalData } from './types';
+import type { Coordinates, RawAirData, SignalData } from './types';
 
 const NATIONWIDE_QUERY = '대한민국';
 
@@ -11,6 +11,9 @@ const App: React.FC = () => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [coordinates, setCoordinates] = useState<Coordinates | null>(null);
+  const [activeLocationQuery, setActiveLocationQuery] = useState<string>(NATIONWIDE_QUERY);
+  const [isLocating, setIsLocating] = useState<boolean>(false);
 
   const processSignalLogic = useCallback((data: RawAirData): SignalData => {
     const isMaskOn = data.pm10 > 80 || data.pm25 > 35;
@@ -20,14 +23,15 @@ const App: React.FC = () => {
     return { isMaskOn, isVentilateOn, isHumidifyOn };
   }, []);
 
-  const fetchData = useCallback(async () => {
+  const fetchData = useCallback(async (query: string) => {
     setIsLoading(true);
     setError(null);
     try {
-      const data = await getAirQualityData(NATIONWIDE_QUERY);
+      const data = await getAirQualityData(query);
       setRawAirData(data);
       setSignalData(processSignalLogic(data));
       setLastUpdated(new Date());
+      setActiveLocationQuery(query);
     } catch (err) {
       console.error(err);
       setError('데이터를 불러올 수 없습니다. 연결 상태를 확인하고 다시 시도해주세요.');
@@ -36,26 +40,113 @@ const App: React.FC = () => {
     }
   }, [processSignalLogic]);
 
+  const resolveLocationQuery = useCallback(async ({ latitude, longitude }: Coordinates) => {
+    try {
+      const response = await fetch(
+        `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${latitude}&lon=${longitude}&accept-language=ko&zoom=10`,
+        {
+          headers: {
+            'Accept': 'application/json',
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error('Reverse geocoding request failed');
+      }
+
+      const data = await response.json();
+      const address = data.address ?? {};
+
+      const district =
+        address.city_district ||
+        address.district ||
+        address.county ||
+        address.borough ||
+        address.suburb;
+      const city =
+        address.city ||
+        address.town ||
+        address.municipality ||
+        address.state;
+      const province = address.state || address.region || address.country;
+
+      const query = [district, city].filter(Boolean).join(' ');
+      return (query || city || province || NATIONWIDE_QUERY) as string;
+    } catch (geoError) {
+      console.error('Failed to resolve location name', geoError);
+      throw new Error('현재 위치 정보를 확인할 수 없습니다.');
+    }
+  }, []);
+
   useEffect(() => {
-    void fetchData();
+    void fetchData(NATIONWIDE_QUERY);
   }, [fetchData]);
 
   const handleRefresh = useCallback(() => {
-    void fetchData();
-  }, [fetchData]);
+    void fetchData(activeLocationQuery);
+  }, [activeLocationQuery, fetchData]);
+
+  const handleRequestLocation = useCallback(() => {
+    if (!('geolocation' in navigator)) {
+      setError('이 기기에서는 위치 서비스를 사용할 수 없습니다.');
+      return;
+    }
+
+    setError(null);
+    setIsLocating(true);
+    setIsLoading(true);
+
+    navigator.geolocation.getCurrentPosition(
+      async (position) => {
+        const nextCoordinates = {
+          latitude: position.coords.latitude,
+          longitude: position.coords.longitude,
+        } satisfies Coordinates;
+
+        try {
+          const query = await resolveLocationQuery(nextCoordinates);
+          await fetchData(query);
+          setCoordinates(nextCoordinates);
+        } catch (geoError) {
+          console.error(geoError);
+          setError('현재 위치의 대기질 정보를 불러오지 못했습니다.');
+          setIsLoading(false);
+        } finally {
+          setIsLocating(false);
+        }
+      },
+      (geoError) => {
+        console.error(geoError);
+        setError('위치 정보를 가져오는 데 실패했습니다. 위치 접근 권한을 확인해주세요.');
+        setIsLocating(false);
+        setIsLoading(false);
+      },
+      {
+        enableHighAccuracy: true,
+        timeout: 10000,
+      },
+    );
+  }, [fetchData, resolveLocationQuery]);
 
   return (
     <MainScreen
       locationName={
-        rawAirData ? `${rawAirData.locationName} · 전국 요약` : '대한민국 대기질 요약'
+        coordinates
+          ? rawAirData?.locationName ?? '현재 위치'
+          : rawAirData
+            ? `${rawAirData.locationName} · 전국 요약`
+            : '대한민국 대기질 요약'
       }
       nationwideData={rawAirData}
-      coordinates={null}
+      coordinates={coordinates}
       signalData={signalData}
       isLoading={isLoading}
       error={error}
       lastUpdated={lastUpdated}
       onRefresh={handleRefresh}
+      onRequestLocation={handleRequestLocation}
+      isLocating={isLocating}
     />
   );
 };

--- a/components/MainScreen.tsx
+++ b/components/MainScreen.tsx
@@ -16,6 +16,8 @@ interface MainScreenProps {
   error: string | null;
   lastUpdated: Date | null;
   onRefresh: () => void;
+  onRequestLocation: () => void;
+  isLocating: boolean;
 }
 
 const MainScreen: React.FC<MainScreenProps> = ({
@@ -27,6 +29,8 @@ const MainScreen: React.FC<MainScreenProps> = ({
   error,
   lastUpdated,
   onRefresh,
+  onRequestLocation,
+  isLocating,
 }) => {
     
   const timeAgo = useMemo(() => {
@@ -104,12 +108,15 @@ const MainScreen: React.FC<MainScreenProps> = ({
       <Header locationName={locationName} onRefresh={onRefresh} />
       <main className="flex-grow flex flex-col items-center w-full gap-6 py-6">
         <NationwideOverview data={nationwideData} isLoading={isLoading} error={error} />
-        {coordinates && (
-          <div className="w-full max-w-2xl">
-            <h2 className="text-lg font-semibold text-dark-text mb-3">현재 위치</h2>
-            <MapView coordinates={coordinates} locationName={locationName} />
-          </div>
-        )}
+        <div className="w-full max-w-2xl">
+          <h2 className="text-lg font-semibold text-dark-text mb-3">현재 위치</h2>
+          <MapView
+            coordinates={coordinates}
+            locationName={locationName}
+            onRequestLocation={onRequestLocation}
+            isLocating={isLocating}
+          />
+        </div>
         <div className="flex flex-col items-center justify-center w-full">
           {renderContent()}
         </div>

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -20,12 +20,18 @@ const defaultIcon = L.icon({
 });
 
 interface MapViewProps {
-  coordinates: Coordinates;
+  coordinates?: Coordinates | null;
   locationName?: string;
+  onRequestLocation?: () => void;
+  isLocating?: boolean;
 }
 
-const MapView: React.FC<MapViewProps> = ({ coordinates, locationName }) => {
-  const { latitude, longitude } = coordinates;
+const MapView: React.FC<MapViewProps> = ({
+  coordinates,
+  locationName,
+  onRequestLocation,
+  isLocating = false,
+}) => {
   const mapRef = useRef<L.Map | null>(null);
 
   const handleMapCreated = useCallback((mapInstance: L.Map) => {
@@ -39,14 +45,15 @@ const MapView: React.FC<MapViewProps> = ({ coordinates, locationName }) => {
     mapInstance.fitBounds(koreaBounds, { padding: [24, 24], animate: true });
   }, []);
 
-  const handleFlyToLocation = () => {
-    if (!mapRef.current) return;
+  useEffect(() => {
+    if (!coordinates || !mapRef.current) return;
 
+    const { latitude, longitude } = coordinates;
     mapRef.current.flyTo([latitude, longitude], 13, {
       animate: true,
       duration: 2,
     });
-  };
+  }, [coordinates]);
 
   return (
     <div className="w-full h-64 sm:h-80 rounded-xl overflow-hidden shadow-md">
@@ -64,24 +71,30 @@ const MapView: React.FC<MapViewProps> = ({ coordinates, locationName }) => {
             url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
             attribution="&copy; <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap</a> contributors"
           />
-          <Marker position={[latitude, longitude]} icon={defaultIcon}>
-            <Popup>
-              {locationName || '선택한 위치'}<br />
-              위도 {latitude.toFixed(4)}, 경도 {longitude.toFixed(4)}
-            </Popup>
-          </Marker>
+          {coordinates && (
+            <Marker position={[coordinates.latitude, coordinates.longitude]} icon={defaultIcon}>
+              <Popup>
+                {locationName || '선택한 위치'}<br />
+                위도 {coordinates.latitude.toFixed(4)}, 경도 {coordinates.longitude.toFixed(4)}
+              </Popup>
+            </Marker>
+          )}
         </MapContainer>
-        <button
-          type="button"
-          onClick={handleFlyToLocation}
-          className={[
-            'absolute right-3 bottom-3 rounded-full',
-            'bg-white/90 backdrop-blur px-4 py-2 text-sm font-medium',
-            'text-dark-text shadow-lg hover:bg-white transition',
-          ].join(' ')}
-        >
-          내 위치로 이동
-        </button>
+        {onRequestLocation && (
+          <button
+            type="button"
+            onClick={onRequestLocation}
+            className={[
+              'absolute right-3 bottom-3 rounded-full',
+              'bg-white/90 backdrop-blur px-4 py-2 text-sm font-medium',
+              'text-dark-text shadow-lg hover:bg-white transition',
+              isLocating ? 'cursor-not-allowed opacity-70' : '',
+            ].join(' ')}
+            disabled={isLocating}
+          >
+            {isLocating ? '위치 확인 중...' : '내 위치'}
+          </button>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add browser geolocation flow to resolve the user’s current position and fetch localized air quality data
- always render the map view, allowing it to request the current position and animate to new coordinates when available
- update map rendering to handle empty coordinates, fit nationwide bounds, and drop markers only after a location is known

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da2817738083288117e4db62964416