### PR TITLE
Add caching for reverse geocode and avoid redundant lookups

### DIFF
--- a/app/src/main/java/com/aircare/Geo.kt
+++ b/app/src/main/java/com/aircare/Geo.kt
@@ -6,12 +6,25 @@ import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.IOException
+import java.util.Collections
+import java.util.LinkedHashMap
+import java.util.Locale
 
 object Geo {
     private val client = OkHttpClient()
     private val gson = Gson()
+    private val cache = Collections.synchronizedMap(
+        object : LinkedHashMap<String, String>(50, 0.75f, true) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, String>): Boolean {
+                return size > 100
+            }
+        }
+    )
 
     fun reverseGeocode(lat: Double, lng: Double, apiKey: String, language: String = "ko"): String? {
+        val cacheKey = String.format(Locale.US, "%.4f,%.4f", lat, lng)
+        cache[cacheKey]?.let { return it }
+
         val url = HttpUrl.Builder()
             .scheme("https")
             .host("maps.googleapis.com")
@@ -37,7 +50,9 @@ object Geo {
                 val body = response.body?.string() ?: return null
                 val geocodeResponse = gson.fromJson(body, GeocodeResponse::class.java)
                 if (geocodeResponse.status == "OK" && geocodeResponse.results.isNotEmpty()) {
-                    geocodeResponse.results.first().formattedAddress
+                    geocodeResponse.results.first().formattedAddress.also { address ->
+                        cache[cacheKey] = address
+                    }
                 } else {
                     null
                 }


### PR DESCRIPTION
## Summary
- add a small LRU cache for reverse geocoding responses keyed by rounded coordinates
- use cached addresses before hitting the API and store successful lookups
- skip reverse geocoding when the camera moves less than 50 meters while still updating the coordinate text

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da317a5d8883288237a67d6e8dae47