### PR TITLE
Add palette toggle for heatmap overlay

### DIFF
--- a/app/src/main/java/com/aircare/MainActivity.kt
+++ b/app/src/main/java/com/aircare/MainActivity.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Bundle
 import android.location.Location
+import android.view.View
 import android.widget.TextView
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
@@ -23,6 +24,7 @@ import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
 import com.google.android.gms.maps.model.LatLngBounds
+import com.google.android.gms.maps.model.TileOverlay
 import com.google.android.gms.maps.model.TileOverlayOptions
 import com.google.android.gms.maps.model.UrlTileProvider
 import com.google.android.material.appbar.MaterialToolbar
@@ -49,6 +51,8 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
     private lateinit var fusedLocationClient: FusedLocationProviderClient
     private var geocodeJob: Job? = null
     private var lastGeocodedTarget: LatLng? = null
+    private var airQualityTileOverlay: TileOverlay? = null
+    private var selectedPalette: PaletteType = PaletteType.DEFAULT
 
     private val locationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
@@ -63,6 +67,10 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        selectedPalette = savedInstanceState?.getString(KEY_SELECTED_PALETTE)?.let { value ->
+            runCatching { PaletteType.valueOf(value) }.getOrNull()
+        } ?: PaletteType.DEFAULT
+
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
@@ -71,6 +79,23 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
         addressTextView = binding.textAddress
         coordinatesTextView = binding.textCoordinates
         updatedAtTextView = binding.textUpdatedAt
+
+        val paletteToggleGroup = binding.paletteToggleGroup
+        paletteToggleGroup.addOnButtonCheckedListener { group, checkedId, isChecked ->
+            if (!isChecked) {
+                if (group.checkedButtonId == View.NO_ID) {
+                    group.check(selectedPalette.buttonId)
+                }
+                return@addOnButtonCheckedListener
+            }
+
+            val palette = PaletteType.fromButtonId(checkedId) ?: return@addOnButtonCheckedListener
+            if (palette != selectedPalette) {
+                selectedPalette = palette
+                updateHeatmapOverlay()
+            }
+        }
+        paletteToggleGroup.check(selectedPalette.buttonId)
 
         val bottomSheetCard: MaterialCardView = binding.bottomSheetContainer
         bottomSheetBehavior = com.google.android.material.bottomsheet.BottomSheetBehavior.from(bottomSheetCard)
@@ -142,7 +167,7 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
         map.uiSettings.isMyLocationButtonEnabled = true
         map.uiSettings.isZoomControlsEnabled = true
 
-        addHeatmapOverlay(map)
+        updateHeatmapOverlay()
 
         map.setOnCameraIdleListener(this)
         map.setOnMyLocationButtonClickListener {
@@ -237,18 +262,26 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
 
     companion object {
         private const val MIN_DISTANCE_TO_GEOCODE_METERS = 50f
+        private const val KEY_SELECTED_PALETTE = "selected_palette"
     }
 
-    private fun addHeatmapOverlay(map: GoogleMap) {
+    private fun updateHeatmapOverlay() {
+        val map = googleMap ?: return
+        airQualityTileOverlay?.remove()
+        airQualityTileOverlay = addHeatmapOverlay(map, selectedPalette)
+    }
+
+    private fun addHeatmapOverlay(map: GoogleMap, palette: PaletteType): TileOverlay? {
         val apiKey = BuildConfig.GOOGLE_MAPS_API_KEY
-        if (apiKey.isBlank()) return
+        if (apiKey.isBlank()) return null
 
         val tileProvider = object : UrlTileProvider(256, 256) {
             override fun getTileUrl(x: Int, y: Int, zoom: Int): URL? {
+                val paletteQuery = palette.queryValue?.let { "&palette=$it" } ?: ""
                 val url = String.format(
                     Locale.US,
-                    "https://tile.googleapis.com/v1/airquality/heatmap/%d/%d/%d.png?key=%s",
-                    zoom, x, y, apiKey
+                    "https://tile.googleapis.com/v1/airquality/heatmap/%d/%d/%d.png?key=%s%s",
+                    zoom, x, y, apiKey, paletteQuery
                 )
                 return try {
                     URL(url)
@@ -257,11 +290,26 @@ class MainActivity : AppCompatActivity(), OnMapReadyCallback, GoogleMap.OnCamera
                 }
             }
         }
-        map.addTileOverlay(
+        return map.addTileOverlay(
             TileOverlayOptions()
                 .tileProvider(tileProvider)
-                .transparency(0.35f)
+                .transparency(palette.transparency)
         )
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        outState.putString(KEY_SELECTED_PALETTE, selectedPalette.name)
+    }
+
+    private enum class PaletteType(val buttonId: Int, val queryValue: String?, val transparency: Float) {
+        DEFAULT(R.id.palette_default_button, null, 0.35f),
+        HIGH_CONTRAST(R.id.palette_high_contrast_button, "high_contrast", 0.25f),
+        COLOR_BLIND(R.id.palette_color_blind_button, "color_blind", 0.2f);
+
+        companion object {
+            fun fromButtonId(buttonId: Int): PaletteType? = values().firstOrNull { it.buttonId == buttonId }
+        }
     }
 
     private fun enableMyLocation() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -71,6 +71,39 @@
                 android:text=""
                 android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
                 android:textColor="?attr/colorOnSurface" />
+
+            <com.google.android.material.button.MaterialButtonToggleGroup
+                android:id="@+id/palette_toggle_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:gravity="center_horizontal"
+                app:selectionRequired="true"
+                app:singleSelection="true">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/palette_default_button"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:text="@string/palette_default" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/palette_high_contrast_button"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginEnd="8dp"
+                    android:text="@string/palette_high_contrast" />
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/palette_color_blind_button"
+                    style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/palette_color_blind" />
+            </com.google.android.material.button.MaterialButtonToggleGroup>
         </LinearLayout>
     </com.google.android.material.card.MaterialCardView>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,7 @@
     <string name="location_permission_denied_message">위치 권한이 필요합니다.</string>
     <string name="permission_denied_message">권한이 거부되었습니다. 설정에서 권한을 허용해주세요.</string>
     <string name="location_unavailable_message">현재 위치를 가져올 수 없습니다.</string>
+    <string name="palette_default">기본</string>
+    <string name="palette_high_contrast">고대비</string>
+    <string name="palette_color_blind">색각 보정</string>
 </resources>


### PR DESCRIPTION
## Summary
- add a bottom sheet palette toggle to let users choose different heatmap palettes
- retain a reference to the air quality tile overlay and rebuild it when the selection changes
- persist the selected palette across configuration changes

## Testing
- Not run (Gradle wrapper not available in repository)


------
https://chatgpt.com/codex/tasks/task_e_68da464f79dc8328ba3d352380ced9b0