### PR TITLE
Refine header and add mobile signal bottom sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 *.local
 local.properties
+app/.gradle/
 
 # Editor directories and files
 .vscode/*

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,21 +18,23 @@ const Header: React.FC<HeaderProps> = ({ locationName, onRefresh }) => {
   };
 
   return (
-    <header className="w-full max-w-5xl mx-auto flex justify-between items-center p-2">
-      <div className="flex items-center gap-2">
-        <LocationIcon className="h-5 w-5 text-ink-muted" />
-        <h1 className="text-lg font-semibold text-ink-strong truncate">{locationName}</h1>
-      </div>
-      <div className="flex items-center gap-3">
-        <button
-          onClick={handleRefreshClick}
-          disabled={isRefreshing}
-          className="p-2 text-ink-muted hover:text-ink-strong transition-colors disabled:opacity-50"
-          aria-label="데이터 새로고침"
-        >
-          <RefreshIcon className={`h-6 w-6 ${isRefreshing ? 'animate-spin' : ''}`} />
-        </button>
-        <ShareButton />
+    <header className="sticky top-0 z-40 w-full bg-gradient-to-r from-primary-soft/80 via-background/80 to-secondary-soft/80 backdrop-blur-xl border-b border-white/10">
+      <div className="max-w-5xl mx-auto flex justify-between items-center px-3 sm:px-4 py-2 sm:py-3">
+        <div className="flex items-center gap-2">
+          <LocationIcon className="h-5 w-5 text-ink-muted" />
+          <h1 className="text-lg font-semibold text-ink-strong truncate">{locationName}</h1>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleRefreshClick}
+            disabled={isRefreshing}
+            className="p-2 text-ink-muted hover:text-ink-strong transition-colors disabled:opacity-50"
+            aria-label="데이터 새로고침"
+          >
+            <RefreshIcon className={`h-6 w-6 ${isRefreshing ? 'animate-spin' : ''}`} />
+          </button>
+          <ShareButton />
+        </div>
       </div>
     </header>
   );

--- a/components/MainScreen.tsx
+++ b/components/MainScreen.tsx
@@ -1,11 +1,11 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import type { SignalData, Coordinates, RawAirData } from '../types';
-import SignalIcon from './SignalIcon';
 import ErrorDisplay from './ErrorDisplay';
 import Header from './Header';
 import { MaskIcon, VentilateIcon, HumidifyIcon } from './Icons';
 import MapView from './MapView';
 import NationwideOverview from './Onboarding';
+import SignalSheet, { SignalSheetItem } from './SignalSheet';
 
 interface MainScreenProps {
   locationName: string;
@@ -50,80 +50,140 @@ const MainScreen: React.FC<MainScreenProps> = ({
     return Math.floor(seconds) + "초 전";
   }, [lastUpdated]);
 
-  const renderContent = () => {
-    if (isLoading) {
-      return (
-        <p className="text-ink-muted text-center text-base">
-          전국 데이터를 불러오는 중입니다...
-        </p>
-      );
+  const [isMapExpanded, setIsMapExpanded] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    const mediaQuery = window.matchMedia('(min-width: 640px)');
+
+    const handleChange = () => {
+      setIsDesktop(mediaQuery.matches);
+      if (mediaQuery.matches) {
+        setIsMapExpanded(true);
+      }
+    };
+
+    handleChange();
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+    } else if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(handleChange);
     }
-    if (error) {
-      return (
-        <ErrorDisplay
-          message={error}
-          lastUpdated={lastUpdated ? `마지막 성공 업데이트: ${timeAgo}` : ''}
-        />
-      );
-    }
-    if (signalData) {
-      return (
-        <div className="grid grid-cols-3 gap-4 sm:gap-8 w-full max-w-2xl">
-          <SignalIcon
-            label="마스크"
-            isOn={signalData.isMaskOn}
-            icon={<MaskIcon />}
-            onColor="bg-danger-soft text-danger"
-            offColor="bg-gray-100 text-ink-muted"
-            recommendation={signalData.isMaskOn ? "착용 권장" : "필요 없음"}
-          />
-          <SignalIcon 
-            label="환기" 
-            isOn={signalData.isVentilateOn} 
-            icon={<VentilateIcon />}
-            onColor="bg-primary-soft text-primary"
-            offColor="bg-gray-100 text-ink-muted"
-            recommendation={signalData.isVentilateOn ? "환기 권장" : "창문 닫기"}
-          />
-          <SignalIcon 
-            label="가습" 
-            isOn={signalData.isHumidifyOn} 
-            icon={<HumidifyIcon />}
-            onColor="bg-secondary-soft text-secondary"
-            offColor="bg-gray-100 text-ink-muted"
-            recommendation={signalData.isHumidifyOn ? "가습 권장" : "습도 적정"}
-          />
-        </div>
-      );
-    }
-    return (
-      <p className="text-ink-muted text-center text-base">
-        전국 대기질 정보를 불러오면 신호가 표시됩니다.
-      </p>
-    );
-  };
+
+    return () => {
+      if (typeof mediaQuery.removeEventListener === 'function') {
+        mediaQuery.removeEventListener('change', handleChange);
+      } else if (typeof mediaQuery.removeListener === 'function') {
+        mediaQuery.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  const signalItems: SignalSheetItem[] = useMemo(() => {
+    if (!signalData) return [];
+
+    return [
+      {
+        key: 'mask',
+        label: '마스크',
+        isOn: signalData.isMaskOn,
+        icon: <MaskIcon />,
+        onColor: 'bg-danger-soft text-danger',
+        offColor: 'bg-gray-100 text-ink-muted',
+        recommendation: signalData.isMaskOn ? '착용 권장' : '필요 없음',
+      },
+      {
+        key: 'ventilate',
+        label: '환기',
+        isOn: signalData.isVentilateOn,
+        icon: <VentilateIcon />,
+        onColor: 'bg-primary-soft text-primary',
+        offColor: 'bg-gray-100 text-ink-muted',
+        recommendation: signalData.isVentilateOn ? '환기 권장' : '창문 닫기',
+      },
+      {
+        key: 'humidify',
+        label: '가습',
+        isOn: signalData.isHumidifyOn,
+        icon: <HumidifyIcon />,
+        onColor: 'bg-secondary-soft text-secondary',
+        offColor: 'bg-gray-100 text-ink-muted',
+        recommendation: signalData.isHumidifyOn ? '가습 권장' : '습도 적정',
+      },
+    ];
+  }, [signalData]);
+
+  const effectiveMapExpanded = isDesktop || isMapExpanded;
 
   return (
-    <div className="min-h-screen w-full flex flex-col items-center p-4 sm:p-6 bg-background">
+    <div className="min-h-screen w-full flex flex-col items-center bg-background">
       <Header locationName={locationName} onRefresh={onRefresh} />
-      <main className="flex-grow flex flex-col items-center w-full gap-6 py-6">
+      <main className="flex-grow flex flex-col items-center w-full gap-6 px-4 sm:px-6 pt-6 pb-36 sm:pb-12">
         <NationwideOverview data={nationwideData} isLoading={isLoading} error={error} />
         <div className="w-full max-w-2xl">
-          <h2 className="text-lg font-semibold text-ink-strong mb-3">현재 위치</h2>
-          <MapView
-            coordinates={coordinates}
-            locationName={locationName}
-            onRequestLocation={onRequestLocation}
-            isLocating={isLocating}
+          <div
+            className={[
+              'relative rounded-3xl border border-white/10 bg-background/80 backdrop-blur',
+              'shadow-2xl transition-all duration-500 overflow-hidden',
+              effectiveMapExpanded ? 'max-h-[32rem]' : 'max-h-[9rem] sm:max-h-[32rem]',
+            ].join(' ')}
+          >
+            <div className="flex items-center justify-between gap-2 px-5 py-4">
+              <div>
+                <h2 className="text-lg font-semibold text-ink-strong">현재 위치</h2>
+                <p className="text-sm text-ink-muted">{locationName}</p>
+              </div>
+              <button
+                type="button"
+                className="sm:hidden inline-flex items-center rounded-full bg-gradient-to-r from-primary-soft to-secondary-soft px-3 py-1.5 text-xs font-semibold text-ink-strong shadow-md"
+                onClick={() => setIsMapExpanded((prev) => !prev)}
+                aria-expanded={effectiveMapExpanded}
+                aria-controls="location-map"
+              >
+                {effectiveMapExpanded ? '숨기기' : '확대'}
+              </button>
+            </div>
+            <div
+              id="location-map"
+              className={[
+                'px-5 pb-5 transition-[max-height,opacity] duration-500 ease-out',
+                effectiveMapExpanded ? 'max-h-[28rem] opacity-100' : 'max-h-0 opacity-0 sm:max-h-[28rem] sm:opacity-100',
+                'overflow-hidden',
+              ].join(' ')}
+            >
+              <div className="h-64 sm:h-80">
+                <MapView
+                  coordinates={coordinates}
+                  locationName={locationName}
+                  onRequestLocation={onRequestLocation}
+                  isLocating={isLocating}
+                  isExpanded={effectiveMapExpanded}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        {error && (
+          <ErrorDisplay
+            message={error}
+            lastUpdated={lastUpdated ? `마지막 성공 업데이트: ${timeAgo}` : ''}
           />
-        </div>
-        <div className="flex flex-col items-center justify-center w-full">
-          {renderContent()}
-        </div>
+        )}
       </main>
       <footer className="w-full text-center p-4 text-ink-muted">
         {lastUpdated && !error && `업데이트: ${timeAgo}`}
       </footer>
+      <SignalSheet
+        title="실내 케어 신호"
+        description={lastUpdated && !error ? `업데이트: ${timeAgo}` : undefined}
+        signalItems={signalItems}
+        isLoading={isLoading}
+        errorMessage={error}
+        emptyMessage="전국 대기질 정보를 불러오면 신호가 표시됩니다."
+      />
     </div>
   );
 };

--- a/components/MapView.tsx
+++ b/components/MapView.tsx
@@ -24,6 +24,7 @@ interface MapViewProps {
   locationName?: string;
   onRequestLocation?: () => void;
   isLocating?: boolean;
+  isExpanded?: boolean;
 }
 
 const MapView: React.FC<MapViewProps> = ({
@@ -31,6 +32,7 @@ const MapView: React.FC<MapViewProps> = ({
   locationName,
   onRequestLocation,
   isLocating = false,
+  isExpanded = true,
 }) => {
   const mapRef = useRef<L.Map | null>(null);
 
@@ -55,9 +57,24 @@ const MapView: React.FC<MapViewProps> = ({
     });
   }, [coordinates]);
 
+  useEffect(() => {
+    if (!mapRef.current) return;
+    const mapInstance = mapRef.current;
+    const timeout = window.setTimeout(() => {
+      mapInstance.invalidateSize();
+    }, 240);
+
+    return () => window.clearTimeout(timeout);
+  }, [isExpanded]);
+
   return (
-    <div className="w-full h-64 sm:h-80 rounded-xl overflow-hidden shadow-md">
-      <div className="relative w-full h-full">
+    <div
+      className={[
+        'relative w-full h-full rounded-3xl overflow-hidden shadow-xl border border-white/10',
+        'bg-background/90 backdrop-blur supports-backdrop-blur:bg-background/70 transition-colors',
+      ].join(' ')}
+    >
+      <div className="absolute inset-0">
         <MapContainer
           center={[36.5, 127.5]}
           zoom={7}
@@ -85,14 +102,15 @@ const MapView: React.FC<MapViewProps> = ({
             type="button"
             onClick={onRequestLocation}
             className={[
-              'absolute right-3 bottom-3 rounded-full',
-              'bg-white/90 backdrop-blur px-4 py-2 text-sm font-medium',
-              'text-ink-strong shadow-lg hover:bg-white transition',
+              'absolute right-4 bottom-4 h-14 w-14 rounded-full shadow-xl',
+              'bg-gradient-to-br from-primary-soft to-secondary-soft text-ink-strong font-semibold',
+              'hover:from-primary-soft/90 hover:to-secondary-soft/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-white/40',
               isLocating ? 'cursor-not-allowed opacity-70' : '',
             ].join(' ')}
             disabled={isLocating}
+            aria-label="내 위치로 이동"
           >
-            {isLocating ? '위치 확인 중...' : '내 위치'}
+            {isLocating ? '로딩' : '내 위치'}
           </button>
         )}
       </div>

--- a/components/SignalSheet.tsx
+++ b/components/SignalSheet.tsx
@@ -1,0 +1,208 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import SignalIcon from './SignalIcon';
+
+export interface SignalSheetItem {
+  key: string;
+  label: string;
+  isOn: boolean;
+  icon: React.ReactNode;
+  onColor: string;
+  offColor: string;
+  recommendation: string;
+}
+
+interface SignalSheetProps {
+  title?: string;
+  description?: string;
+  signalItems: SignalSheetItem[];
+  isLoading?: boolean;
+  errorMessage?: string | null;
+  emptyMessage?: string;
+}
+
+const MOBILE_COLLAPSED_HEIGHT = 132;
+
+const SignalSheet: React.FC<SignalSheetProps> = ({
+  title = '실내 케어 신호',
+  description,
+  signalItems,
+  isLoading = false,
+  errorMessage,
+  emptyMessage = '전국 대기질 정보를 불러오면 신호가 표시됩니다.',
+}) => {
+  const hasSignals = signalItems.length > 0 && !isLoading && !errorMessage;
+
+  const message = useMemo(() => {
+    if (isLoading) {
+      return '전국 데이터를 불러오는 중입니다...';
+    }
+    if (errorMessage) {
+      return errorMessage;
+    }
+    return emptyMessage;
+  }, [emptyMessage, errorMessage, isLoading]);
+
+  const messageTone = errorMessage ? 'text-danger' : 'text-ink-muted';
+
+  const sheetRef = useRef<HTMLDivElement | null>(null);
+  const startYRef = useRef(0);
+  const startTranslateRef = useRef(0);
+  const latestTranslateRef = useRef(0);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [translateY, setTranslateY] = useState(0);
+  const [maxTranslate, setMaxTranslate] = useState(0);
+
+  latestTranslateRef.current = translateY;
+
+  const updateMetrics = useCallback(() => {
+    if (!sheetRef.current) return;
+    const fullHeight = sheetRef.current.scrollHeight;
+    const collapsedOffset = Math.max(fullHeight - MOBILE_COLLAPSED_HEIGHT, 0);
+    setMaxTranslate(collapsedOffset);
+    if (!isExpanded && !isDragging) {
+      setTranslateY(collapsedOffset);
+      latestTranslateRef.current = collapsedOffset;
+    }
+  }, [isDragging, isExpanded]);
+
+  useEffect(() => {
+    updateMetrics();
+  }, [updateMetrics, signalItems, isLoading, errorMessage, emptyMessage]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const handleResize = () => updateMetrics();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [updateMetrics]);
+
+  useEffect(() => {
+    if (isDragging) return;
+    const target = isExpanded ? 0 : maxTranslate;
+    setTranslateY(target);
+    latestTranslateRef.current = target;
+  }, [isDragging, isExpanded, maxTranslate]);
+
+  const beginDrag = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (
+        (typeof window !== 'undefined' && window.matchMedia('(min-width: 640px)').matches) ||
+        maxTranslate <= 0
+      ) {
+        return;
+      }
+      event.preventDefault();
+      setIsDragging(true);
+      startYRef.current = event.clientY;
+      startTranslateRef.current = latestTranslateRef.current;
+    },
+    [maxTranslate],
+  );
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMove = (event: PointerEvent) => {
+      const diff = event.clientY - startYRef.current;
+      const next = Math.min(Math.max(startTranslateRef.current + diff, 0), maxTranslate);
+      setTranslateY(next);
+      latestTranslateRef.current = next;
+    };
+
+    const handleRelease = () => {
+      setIsDragging(false);
+      const shouldExpand = latestTranslateRef.current < maxTranslate / 2;
+      setIsExpanded(shouldExpand);
+    };
+
+    window.addEventListener('pointermove', handleMove);
+    window.addEventListener('pointerup', handleRelease);
+    window.addEventListener('pointercancel', handleRelease);
+
+    return () => {
+      window.removeEventListener('pointermove', handleMove);
+      window.removeEventListener('pointerup', handleRelease);
+      window.removeEventListener('pointercancel', handleRelease);
+    };
+  }, [isDragging, maxTranslate]);
+
+  const toggleExpansion = useCallback(() => {
+    setIsExpanded((prev) => !prev);
+  }, []);
+
+  const desktopContent = hasSignals ? (
+    <div className="grid grid-cols-3 gap-6">
+      {signalItems.map((item) => (
+        <SignalIcon key={item.key} {...item} />
+      ))}
+    </div>
+  ) : (
+    <p className={`text-sm ${messageTone} text-center py-6`}>{message}</p>
+  );
+
+  const mobileContent = hasSignals ? (
+    <div className="flex gap-4 overflow-x-auto snap-x snap-mandatory pb-4 -mx-1 px-1">
+      {signalItems.map((item) => (
+        <div key={item.key} className="snap-center shrink-0 w-56">
+          <SignalIcon {...item} />
+        </div>
+      ))}
+    </div>
+  ) : (
+    <p className={`text-sm ${messageTone} text-center py-4`}>{message}</p>
+  );
+
+  return (
+    <>
+      <div className="hidden sm:flex w-full justify-center">
+        <div className="w-full max-w-3xl rounded-3xl border border-white/10 bg-background/80 backdrop-blur px-8 py-6 shadow-2xl">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-xl font-semibold text-ink-strong">{title}</h2>
+              {description && <p className="text-sm text-ink-muted mt-1">{description}</p>}
+            </div>
+          </div>
+          <div className="mt-6">{desktopContent}</div>
+        </div>
+      </div>
+
+      <div className="sm:hidden fixed inset-x-0 bottom-0 z-40 px-4 pb-4">
+        <div
+          ref={sheetRef}
+          className={`rounded-3xl border border-white/10 bg-background/95 shadow-2xl backdrop-blur-xl transition-transform duration-500 ${
+            isDragging ? 'duration-0' : ''
+          }`}
+          style={{ transform: `translateY(${translateY}px)` }}
+        >
+          <div className="flex flex-col">
+            <div
+              className="flex flex-col items-center gap-2 pt-3 pb-2 cursor-grab active:cursor-grabbing"
+              onPointerDown={beginDrag}
+            >
+              <span className="h-1.5 w-16 rounded-full bg-white/40" />
+              <button
+                type="button"
+                onClick={toggleExpansion}
+                className="text-xs font-semibold text-ink-muted"
+                aria-label={isExpanded ? '신호 패널 접기' : '신호 패널 펼치기'}
+                aria-expanded={isExpanded}
+              >
+                {isExpanded ? '아래로 내리기' : '위로 올리기'}
+              </button>
+            </div>
+            <div className="px-5 pb-5">
+              <div className="flex items-center justify-between gap-3">
+                <h2 className="text-base font-semibold text-ink-strong">{title}</h2>
+                {description && <span className="text-xs text-ink-muted">{description}</span>}
+              </div>
+              <div className="mt-3">{mobileContent}</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default SignalSheet;


### PR DESCRIPTION
## Summary
- make the header sticky with a translucent gradient backdrop so the location tools stay visible
- wrap the map view inside a collapsible card on mobile and update the location control to an elevated FAB
- extract the signal grid into a reusable bottom sheet component with drag-up interaction and a swipeable carousel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da54540e808328a6efbb9e7b89b8f2