### PR TITLE
Enhance signal icon animations and styling

### DIFF
--- a/components/SignalIcon.tsx
+++ b/components/SignalIcon.tsx
@@ -10,20 +10,45 @@ interface SignalIconProps {
   recommendation: string;
 }
 
+const extractPrefixedClasses = (classNames: string, prefix: string) =>
+  classNames
+    .split(' ')
+    .filter((cls) => cls.startsWith(prefix))
+    .join(' ');
+
 const SignalIcon: React.FC<SignalIconProps> = ({ label, isOn, icon, onColor, offColor, recommendation }) => {
-  const baseClasses = 'flex flex-col items-center justify-center p-4 sm:p-6 aspect-square rounded-2xl shadow-sm transition-all duration-300 transform hover:scale-105';
-  const colorClasses = isOn ? onColor : offColor;
-  const iconWrapperClasses = 'flex items-center justify-center w-16 h-16 sm:w-20 sm:h-20 rounded-full mb-3 transition-colors duration-300';
+  const baseClasses =
+    'relative flex flex-col items-center justify-center p-4 sm:p-6 aspect-square rounded-2xl transition-all duration-300 transform hover:scale-105';
+  const containerStateClasses = isOn ? 'bg-white/95 shadow-xl animate-signal-active' : 'bg-white shadow-sm';
+
+  const offBackgroundClasses = extractPrefixedClasses(offColor, 'bg-');
+  const activeTextClasses = extractPrefixedClasses(onColor, 'text-');
+  const inactiveTextClasses = extractPrefixedClasses(offColor, 'text-');
+  const iconTextClasses = isOn ? activeTextClasses : inactiveTextClasses;
+
+  const iconWrapperBaseClasses =
+    'relative flex items-center justify-center w-16 h-16 sm:w-20 sm:h-20 rounded-full mb-3 transition-all duration-500 overflow-hidden';
+  const iconWrapperStateClasses = isOn
+    ? 'bg-gradient-to-br from-brand-primary to-brand-secondary signal-badge-glow'
+    : `${offBackgroundClasses} shadow-inner`;
 
   return (
-    <div className={`${baseClasses} ${isOn ? 'bg-white' : 'bg-white'}`}>
-      <div className={`${iconWrapperClasses} ${colorClasses}`}>
-        <div className="w-10 h-10 sm:w-12 sm:h-12">{icon}</div>
+    <div className={`${baseClasses} ${containerStateClasses}`}>
+      <div className={`${iconWrapperBaseClasses} ${iconWrapperStateClasses}`}>
+        {isOn && (
+          <div className="absolute inset-[-10%] rounded-full bg-brand-primary/20 blur-2xl opacity-80" aria-hidden />
+        )}
+        {isOn && (
+          <div className="absolute inset-0 rounded-full bg-white/15 mix-blend-soft-light" aria-hidden />
+        )}
+        <div className={`relative z-10 flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 ${iconTextClasses}`}>
+          {icon}
+        </div>
       </div>
       <h3 className="text-base sm:text-xl font-bold text-ink-strong">{label}</h3>
       <p
-        className={`text-sm sm:text-base font-medium ${
-          isOn ? 'text-ink-strong' : 'text-ink-muted'
+        className={`text-sm sm:text-base font-medium transition-transform transition-opacity duration-500 ease-out transform ${
+          isOn ? 'text-ink-strong opacity-100 translate-y-0' : 'text-ink-muted opacity-80 translate-y-1'
         }`}
       >
         {recommendation}

--- a/index.html
+++ b/index.html
@@ -22,6 +22,8 @@
               'ink-soft': '#96A4C1',
               danger: '#FF5A5F',
               'danger-soft': '#FFE5E8',
+              'brand-primary': '#0967FF',
+              'brand-secondary': '#7CB7FF',
             },
             backgroundImage: {
               'aurora-sky':
@@ -35,6 +37,40 @@
         },
       }
     </script>
+    <style type="text/tailwindcss">
+      @layer utilities {
+        @keyframes signal-float {
+          0%,
+          100% {
+            transform: translateY(0) scale(1);
+          }
+          50% {
+            transform: translateY(-6px) scale(1.02);
+          }
+        }
+
+        @keyframes signal-pulse {
+          0%,
+          100% {
+            box-shadow: 0 14px 35px rgba(9, 103, 255, 0.18);
+          }
+          50% {
+            box-shadow: 0 20px 48px rgba(9, 103, 255, 0.28);
+          }
+        }
+
+        .animate-signal-active {
+          animation: signal-float 6s ease-in-out infinite, signal-pulse 3.5s ease-in-out infinite;
+        }
+
+        .signal-badge-glow {
+          box-shadow:
+            inset 0 6px 14px rgba(255, 255, 255, 0.35),
+            0 0 0 4px rgba(255, 255, 255, 0.3),
+            0 24px 48px rgba(9, 103, 255, 0.35);
+        }
+      }
+    </style>
   <script type="importmap">
 {
   "imports": {


### PR DESCRIPTION
## Summary
- animate active signal cards with custom Tailwind float and pulse utilities
- wrap signal icons in a gradient badge with glow effects driven by new utility classes
- smooth the recommendation copy transitions when toggling between on and off states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da56f9342c8328bec370b681731317