### PR TITLE
Enhance main screen visuals with gradient depth effects

### DIFF
--- a/components/MainScreen.tsx
+++ b/components/MainScreen.tsx
@@ -119,10 +119,18 @@ const MainScreen: React.FC<MainScreenProps> = ({
   const effectiveMapExpanded = isDesktop || isMapExpanded;
 
   return (
-    <div className="min-h-screen w-full flex flex-col items-center bg-background">
+    <div
+      className="relative isolate min-h-screen w-full overflow-hidden bg-ocean-dawn flex flex-col items-center before:content-[''] before:absolute before:-top-56 before:-left-32 before:h-[36rem] before:w-[36rem] before:rounded-full before:bg-gradient-to-br before:from-primary/30 before:via-secondary/20 before:to-white/10 before:blur-3xl before:opacity-80 before:-z-10 after:content-[''] after:absolute after:-bottom-64 after:-right-24 after:h-[40rem] after:w-[40rem] after:rounded-full after:bg-gradient-to-br after:from-secondary/25 after:via-primary/20 after:to-white/5 after:blur-3xl after:opacity-70 after:-z-10"
+    >
       <Header locationName={locationName} onRefresh={onRefresh} />
-      <main className="flex-grow flex flex-col items-center w-full gap-6 px-4 sm:px-6 pt-6 pb-36 sm:pb-12">
-        <NationwideOverview data={nationwideData} isLoading={isLoading} error={error} />
+      <main className="relative z-10 flex-grow flex flex-col items-center w-full gap-6 px-4 sm:px-6 pt-6 pb-36 sm:pb-12">
+        <div className="w-full max-w-4xl">
+          <div className="group relative overflow-hidden rounded-[2.5rem] border border-white/30 bg-white/20 backdrop-blur-3xl shadow-[0_25px_70px_-30px_rgba(18,40,76,0.65)] transition-all duration-500 hover:-translate-y-1 hover:shadow-[0_35px_90px_-30px_rgba(18,40,76,0.7)]">
+            <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-white/30 via-white/10 to-white/5 opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+            <div className="pointer-events-none absolute inset-px rounded-[2.45rem] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.15)]" />
+            <NationwideOverview data={nationwideData} isLoading={isLoading} error={error} />
+          </div>
+        </div>
         <div className="w-full max-w-2xl">
           <div
             className={[

--- a/components/Onboarding.tsx
+++ b/components/Onboarding.tsx
@@ -24,24 +24,50 @@ const NationwideOverview: React.FC<NationwideOverviewProps> = ({ data, isLoading
     }
 
     if (data) {
+      const stats = [
+        {
+          key: 'location',
+          label: '주요 지역',
+          value: data.locationName,
+          valueClass: 'text-2xl font-semibold text-ink-strong',
+          wrapperClass: '',
+        },
+        {
+          key: 'pm10',
+          label: '미세먼지 (PM10)',
+          value: `${Math.round(data.pm10)} ㎍/㎥`,
+          valueClass: 'text-3xl font-bold text-ink-strong',
+          wrapperClass: '',
+        },
+        {
+          key: 'pm25',
+          label: '초미세먼지 (PM2.5)',
+          value: `${Math.round(data.pm25)} ㎍/㎥`,
+          valueClass: 'text-3xl font-bold text-ink-strong',
+          wrapperClass: '',
+        },
+        {
+          key: 'humidity',
+          label: '상대 습도',
+          value: `${Math.round(data.humidity)}%`,
+          valueClass: 'text-3xl font-bold text-ink-strong',
+          wrapperClass: 'sm:col-span-3 sm:max-w-2xl sm:mx-auto',
+        },
+      ];
+
       return (
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <div className="rounded-2xl bg-surface p-4 text-center">
-            <p className="text-sm text-ink-muted">주요 지역</p>
-            <p className="text-2xl font-semibold text-ink-strong">{data.locationName}</p>
-          </div>
-          <div className="rounded-2xl bg-surface p-4 text-center">
-            <p className="text-sm text-ink-muted">미세먼지 (PM10)</p>
-            <p className="text-3xl font-bold text-ink-strong">{Math.round(data.pm10)} ㎍/㎥</p>
-          </div>
-          <div className="rounded-2xl bg-surface p-4 text-center">
-            <p className="text-sm text-ink-muted">초미세먼지 (PM2.5)</p>
-            <p className="text-3xl font-bold text-ink-strong">{Math.round(data.pm25)} ㎍/㎥</p>
-          </div>
-          <div className="rounded-2xl bg-surface p-4 text-center sm:col-span-3 sm:max-w-md sm:mx-auto">
-            <p className="text-sm text-ink-muted">상대 습도</p>
-            <p className="text-3xl font-bold text-ink-strong">{Math.round(data.humidity)}%</p>
-          </div>
+        <div className="grid grid-cols-1 gap-5 sm:grid-cols-3">
+          {stats.map((stat) => (
+            <div key={stat.key} className={`group relative ${stat.wrapperClass}`}>
+              <div className="relative overflow-hidden rounded-[1.75rem] bg-gradient-to-br from-white/70 via-white/20 to-white/5 p-[1px] transition-all duration-500 group-hover:from-white/80 group-hover:via-white/25 group-hover:to-white/10">
+                <div className="relative flex h-full transform-gpu translate-y-1 flex-col items-center justify-center gap-2 rounded-[1.67rem] bg-white/15 px-6 py-6 text-center backdrop-blur-xl shadow-[0_20px_45px_-25px_rgba(16,38,74,0.65)] transition-all duration-500 group-hover:-translate-y-1 group-hover:shadow-[0_28px_60px_-28px_rgba(16,38,74,0.7)]">
+                  <div className="pointer-events-none absolute inset-0 rounded-[1.67rem] bg-gradient-to-br from-white/35 via-transparent to-white/15 opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+                  <p className="text-sm font-medium uppercase tracking-[0.18em] text-ink-soft">{stat.label}</p>
+                  <p className={stat.valueClass}>{stat.value}</p>
+                </div>
+              </div>
+            </div>
+          ))}
         </div>
       );
     }
@@ -50,10 +76,13 @@ const NationwideOverview: React.FC<NationwideOverviewProps> = ({ data, isLoading
   };
 
   return (
-    <section className="w-full max-w-4xl mx-auto bg-white rounded-3xl shadow-md p-6 sm:p-10">
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
+    <section className="relative z-10 w-full px-6 py-8 sm:px-10 sm:py-12">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
         <div className="flex items-center gap-4">
-          <LogoIcon className="h-12 w-12 text-primary" />
+          <div className="relative flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-primary/80 via-secondary/70 to-white/60 shadow-[0_18px_35px_-18px_rgba(9,103,255,0.65)]">
+            <div className="absolute inset-[2px] rounded-[1.35rem] bg-white/15 backdrop-blur-xl" />
+            <LogoIcon className="relative z-10 h-10 w-10 text-white drop-shadow-[0_6px_10px_rgba(9,103,255,0.45)]" />
+          </div>
           <div>
             <h2 className="text-2xl sm:text-3xl font-bold text-ink-strong">대한민국 대기질 한눈에 보기</h2>
             <p className="text-ink-muted text-base sm:text-lg">


### PR DESCRIPTION
## Summary
- replace the main screen background with a new gradient canvas and ambient glow pseudo-elements
- wrap the nationwide overview in a floating glassmorphism card with responsive hover depth
- restyle nationwide metrics into layered gradient tiles that feel three-dimensional

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68da584c47b083289e060851bb29ecc1