### PR TITLE
feat: add user agent header to Nominatim reverse geocoding

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import MainScreen from './components/MainScreen';
 import { getAirQualityData } from './services/geminiService';
+import { NOMINATIM_USER_AGENT } from './services/nominatim';
 import type { Coordinates, RawAirData, SignalData } from './types';
 
 const NATIONWIDE_QUERY = '대한민국';
@@ -48,7 +49,8 @@ const App: React.FC = () => {
         `https://nominatim.openstreetmap.org/reverse?format=jsonv2&lat=${latitude}&lon=${longitude}&accept-language=ko&zoom=10`,
         {
           headers: {
-            'Accept': 'application/json',
+            Accept: 'application/json',
+            'User-Agent': NOMINATIM_USER_AGENT,
           },
         },
       );

--- a/services/nominatim.ts
+++ b/services/nominatim.ts
@@ -1,0 +1,2 @@
+export const NOMINATIM_USER_AGENT =
+  'AIR-CARE/1.0 (https://ai.studio/apps/drive/127IEIc4eg4TQB7G3pPbMCIPppKkFojQN; contact: support@air-care.app)';


### PR DESCRIPTION
## Summary
- add a shared constant for the Nominatim User-Agent header
- include the identifying header in reverse geocoding fetch calls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dce3bf120c8328beea2e6d11da2837