### PR TITLE
feat: add KMA village forecast integration

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,2 @@
+GEMINI_API_KEY=your-gemini-api-key
+KMA_SERVICE_KEY=your-kma-service-key

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ View your app in AI Studio: https://ai.studio/apps/drive/127IEIc4eg4TQB7G3pPbMCI
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Copy `.env.local.example` to `.env.local` and set the required keys:
+   - `GEMINI_API_KEY`: Gemini API key for 대기질 요약
+   - `KMA_SERVICE_KEY`: 한국 기상청 마을예보 OpenAPI 서비스 키
 3. Run the app:
    `npm run dev`
 

--- a/components/ForecastTable.tsx
+++ b/components/ForecastTable.tsx
@@ -1,0 +1,102 @@
+import React, { useMemo } from 'react';
+import type { ForecastRow } from '../types';
+import { PRECIPITATION_TYPE_LABELS, SKY_CONDITION_LABELS } from '../types';
+
+interface ForecastTableProps {
+  rows: ForecastRow[];
+  isLoading: boolean;
+}
+
+const formatDateLabel = (fcstDate: string) => {
+  if (fcstDate.length !== 8) return fcstDate;
+  const month = Number(fcstDate.slice(4, 6));
+  const day = Number(fcstDate.slice(6, 8));
+  return `${month}월 ${day}일`;
+};
+
+const formatTimeLabel = (fcstTime: string) => {
+  if (fcstTime.length < 2) return fcstTime;
+  const hour = fcstTime.slice(0, 2);
+  return `${hour}시`;
+};
+
+const ForecastTable: React.FC<ForecastTableProps> = ({ rows, isLoading }) => {
+  const displayedRows = useMemo(() => rows.slice(0, 12), [rows]);
+
+  if (isLoading && displayedRows.length === 0) {
+    return (
+      <section className="relative rounded-3xl border border-white/10 bg-background/80 backdrop-blur px-6 py-6 shadow-2xl">
+        <div className="flex items-center justify-between pb-4">
+          <div>
+            <h2 className="text-lg font-semibold text-ink-strong">단기 예보</h2>
+            <p className="text-sm text-ink-muted">기상청 마을예보 (TMP, POP, PTY, SKY)</p>
+          </div>
+        </div>
+        <div className="flex flex-col items-center justify-center gap-3 py-10">
+          <div className="h-10 w-10 border-4 border-primary border-t-transparent rounded-full animate-spin" aria-hidden />
+          <p className="text-sm text-ink-muted">예보 데이터를 불러오는 중...</p>
+        </div>
+      </section>
+    );
+  }
+
+  if (displayedRows.length === 0) {
+    return (
+      <section className="relative rounded-3xl border border-white/10 bg-background/80 backdrop-blur px-6 py-6 shadow-2xl">
+        <div className="flex items-center justify-between pb-2">
+          <div>
+            <h2 className="text-lg font-semibold text-ink-strong">단기 예보</h2>
+            <p className="text-sm text-ink-muted">기상청 마을예보 (TMP, POP, PTY, SKY)</p>
+          </div>
+        </div>
+        <p className="text-sm text-ink-muted">표시할 예보 데이터가 없습니다.</p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-background/80 backdrop-blur shadow-2xl">
+      <div className="flex items-center justify-between px-6 pt-6 pb-3">
+        <div>
+          <h2 className="text-lg font-semibold text-ink-strong">단기 예보</h2>
+          <p className="text-sm text-ink-muted">기상청 마을예보 (TMP, POP, PTY, SKY)</p>
+        </div>
+      </div>
+      <div className="px-6 pb-6">
+        <div className="overflow-hidden rounded-2xl bg-slate-900/70 text-slate-100">
+          <table className="min-w-full table-fixed text-left text-xs font-mono sm:text-sm">
+            <thead>
+              <tr className="bg-slate-800/80 text-slate-200 uppercase tracking-wider">
+                <th className="px-4 py-3">일자</th>
+                <th className="px-4 py-3">시간</th>
+                <th className="px-4 py-3">기온 (℃)</th>
+                <th className="px-4 py-3">강수확률 (%)</th>
+                <th className="px-4 py-3">강수형태</th>
+                <th className="px-4 py-3">하늘상태</th>
+              </tr>
+            </thead>
+            <tbody>
+              {displayedRows.map((row) => {
+                const precipitationLabel =
+                  PRECIPITATION_TYPE_LABELS[row.precipitationType] ?? '정보 없음';
+                const skyLabel = SKY_CONDITION_LABELS[row.skyCondition] ?? '정보 없음';
+                return (
+                  <tr key={`${row.fcstDate}-${row.fcstTime}`} className="border-t border-slate-800/70">
+                    <td className="px-4 py-2 align-top text-slate-200">{formatDateLabel(row.fcstDate)}</td>
+                    <td className="px-4 py-2 align-top text-slate-200">{formatTimeLabel(row.fcstTime)}</td>
+                    <td className="px-4 py-2 align-top text-slate-50">{row.temperature.toFixed(1)}</td>
+                    <td className="px-4 py-2 align-top text-slate-50">{`${Math.round(row.precipitationProbability)}%`}</td>
+                    <td className="px-4 py-2 align-top text-slate-50">{precipitationLabel}</td>
+                    <td className="px-4 py-2 align-top text-slate-50">{skyLabel}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ForecastTable;

--- a/components/MainScreen.tsx
+++ b/components/MainScreen.tsx
@@ -1,16 +1,18 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import type { SignalData, Coordinates, RawAirData } from '../types';
+import type { SignalData, Coordinates, RawAirData, ForecastRow } from '../types';
 import ErrorDisplay from './ErrorDisplay';
 import Header from './Header';
 import { MaskIcon, VentilateIcon, HumidifyIcon } from './Icons';
 import MapView from './MapView';
 import NationwideOverview from './Onboarding';
 import SignalSheet, { SignalSheetItem } from './SignalSheet';
+import ForecastTable from './ForecastTable';
 
 interface MainScreenProps {
   locationName: string;
   coordinates: Coordinates | null;
   nationwideData: RawAirData | null;
+  forecastRows: ForecastRow[];
   signalData: SignalData | null;
   isLoading: boolean;
   error: string | null;
@@ -24,6 +26,7 @@ const MainScreen: React.FC<MainScreenProps> = ({
   locationName,
   coordinates,
   nationwideData,
+  forecastRows,
   signalData,
   isLoading,
   error,
@@ -173,6 +176,9 @@ const MainScreen: React.FC<MainScreenProps> = ({
               </div>
             </div>
           </div>
+        </div>
+        <div className="w-full max-w-3xl">
+          <ForecastTable rows={forecastRows} isLoading={isLoading} />
         </div>
         {error && (
           <ErrorDisplay

--- a/services/kmaForecast.ts
+++ b/services/kmaForecast.ts
@@ -1,0 +1,195 @@
+import type { ForecastRow, GridCoordinates, PrecipitationTypeCode, SkyConditionCode } from '../types';
+
+const DEGREE_TO_RAD = Math.PI / 180;
+const EARTH_RADIUS = 6371.00877; // km
+const GRID_SPACING = 5.0; // km
+const STANDARD_PARALLEL_1 = 30.0;
+const STANDARD_PARALLEL_2 = 60.0;
+const REFERENCE_LONGITUDE = 126.0;
+const REFERENCE_LATITUDE = 38.0;
+const ORIGIN_X = 43;
+const ORIGIN_Y = 136;
+
+const BASE_TIMES = ['0200', '0500', '0800', '1100', '1400', '1700', '2000', '2300'] as const;
+
+export const latLonToGrid = (latitude: number, longitude: number): GridCoordinates => {
+  const re = EARTH_RADIUS / GRID_SPACING;
+  const slat1 = STANDARD_PARALLEL_1 * DEGREE_TO_RAD;
+  const slat2 = STANDARD_PARALLEL_2 * DEGREE_TO_RAD;
+  const olon = REFERENCE_LONGITUDE * DEGREE_TO_RAD;
+  const olat = REFERENCE_LATITUDE * DEGREE_TO_RAD;
+
+  let sn = Math.tan(Math.PI * 0.25 + slat2 * 0.5) / Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+  sn = Math.log(Math.cos(slat1) / Math.cos(slat2)) / Math.log(sn);
+  let sf = Math.tan(Math.PI * 0.25 + slat1 * 0.5);
+  sf = (Math.pow(sf, sn) * Math.cos(slat1)) / sn;
+  let ro = Math.tan(Math.PI * 0.25 + olat * 0.5);
+  ro = (re * sf) / Math.pow(ro, sn);
+
+  let ra = Math.tan(Math.PI * 0.25 + latitude * DEGREE_TO_RAD * 0.5);
+  ra = (re * sf) / Math.pow(ra, sn);
+  let theta = longitude * DEGREE_TO_RAD - olon;
+  if (theta > Math.PI) theta -= 2.0 * Math.PI;
+  if (theta < -Math.PI) theta += 2.0 * Math.PI;
+  theta *= sn;
+
+  const nx = Math.floor(ra * Math.sin(theta) + ORIGIN_X + 0.5);
+  const ny = Math.floor(ro - ra * Math.cos(theta) + ORIGIN_Y + 0.5);
+
+  return { nx, ny };
+};
+
+const padNumber = (value: number) => value.toString().padStart(2, '0');
+
+export const latestBaseDateTime = (now: Date = new Date()) => {
+  const utc = now.getTime() + now.getTimezoneOffset() * 60_000;
+  const kst = new Date(utc + 9 * 60 * 60 * 1000);
+  const year = kst.getFullYear();
+  const month = padNumber(kst.getMonth() + 1);
+  const day = padNumber(kst.getDate());
+  const current = kst.getHours() * 100 + kst.getMinutes();
+
+  let baseDate = `${year}${month}${day}`;
+  let baseTime = BASE_TIMES[0];
+
+  for (const time of BASE_TIMES) {
+    const baseValue = Number(time);
+    if (current >= baseValue) {
+      baseTime = time;
+    }
+  }
+
+  if (current < Number(BASE_TIMES[0])) {
+    kst.setDate(kst.getDate() - 1);
+    baseDate = `${kst.getFullYear()}${padNumber(kst.getMonth() + 1)}${padNumber(kst.getDate())}`;
+    baseTime = BASE_TIMES[BASE_TIMES.length - 1];
+  }
+
+  return { baseDate, baseTime } as const;
+};
+
+const ensurePrecipitationType = (value: number): PrecipitationTypeCode => {
+  const validCodes: PrecipitationTypeCode[] = [0, 1, 2, 3, 4, 5, 6, 7];
+  return validCodes.includes(value as PrecipitationTypeCode) ? (value as PrecipitationTypeCode) : 0;
+};
+
+const ensureSkyCondition = (value: number): SkyConditionCode => {
+  const validCodes: SkyConditionCode[] = [1, 3, 4];
+  return validCodes.includes(value as SkyConditionCode) ? (value as SkyConditionCode) : 1;
+};
+
+type ForecastCategory = 'TMP' | 'POP' | 'PTY' | 'SKY';
+
+interface KMAApiItem {
+  category: ForecastCategory;
+  fcstDate: string;
+  fcstTime: string;
+  fcstValue: string;
+}
+
+interface KMAApiResponse {
+  response?: {
+    header?: { resultCode?: string };
+    body?: {
+      items?: { item?: KMAApiItem[] };
+    };
+  };
+}
+
+const SERVICE_ENDPOINT = 'https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst';
+
+export const getVillageForecast = async (latitude: number, longitude: number): Promise<ForecastRow[]> => {
+  const serviceKey = process.env.KMA_SERVICE_KEY ?? import.meta.env.VITE_KMA_SERVICE_KEY;
+  if (!serviceKey) {
+    console.warn('KMA_SERVICE_KEY is not defined. Skipping forecast fetch.');
+    return [];
+  }
+
+  const { nx, ny } = latLonToGrid(latitude, longitude);
+  const { baseDate, baseTime } = latestBaseDateTime();
+
+  const searchParams = new URLSearchParams({
+    serviceKey,
+    pageNo: '1',
+    numOfRows: '200',
+    dataType: 'JSON',
+    base_date: baseDate,
+    base_time: baseTime,
+    nx: String(nx),
+    ny: String(ny),
+  });
+
+  const response = await fetch(`${SERVICE_ENDPOINT}?${searchParams.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch KMA forecast: ${response.status}`);
+  }
+
+  const payload = (await response.json()) as KMAApiResponse;
+  const items = payload.response?.body?.items?.item ?? [];
+
+  const grouped = new Map<string, Partial<ForecastRow>>();
+
+  for (const item of items) {
+    if (!['TMP', 'POP', 'PTY', 'SKY'].includes(item.category)) continue;
+    const key = `${item.fcstDate}_${item.fcstTime}`;
+    const existing = grouped.get(key) ?? { fcstDate: item.fcstDate, fcstTime: item.fcstTime };
+
+    const value = Number(item.fcstValue);
+
+    switch (item.category) {
+      case 'TMP':
+        if (!Number.isNaN(value)) {
+          existing.temperature = value;
+        }
+        break;
+      case 'POP':
+        if (!Number.isNaN(value)) {
+          existing.precipitationProbability = value;
+        }
+        break;
+      case 'PTY':
+        if (!Number.isNaN(value)) {
+          existing.precipitationType = ensurePrecipitationType(value);
+        }
+        break;
+      case 'SKY':
+        if (!Number.isNaN(value)) {
+          existing.skyCondition = ensureSkyCondition(value);
+        }
+        break;
+      default:
+        break;
+    }
+
+    grouped.set(key, existing);
+  }
+
+  const rows: ForecastRow[] = [];
+
+  for (const entry of grouped.values()) {
+    if (
+      entry.fcstDate &&
+      entry.fcstTime &&
+      typeof entry.temperature === 'number' &&
+      typeof entry.precipitationProbability === 'number' &&
+      typeof entry.precipitationType !== 'undefined' &&
+      typeof entry.skyCondition !== 'undefined'
+    ) {
+      rows.push({
+        fcstDate: entry.fcstDate,
+        fcstTime: entry.fcstTime,
+        temperature: entry.temperature,
+        precipitationProbability: entry.precipitationProbability,
+        precipitationType: entry.precipitationType,
+        skyCondition: entry.skyCondition,
+      });
+    }
+  }
+
+  return rows.sort((a, b) => {
+    const dateDiff = a.fcstDate.localeCompare(b.fcstDate);
+    if (dateDiff !== 0) return dateDiff;
+    return a.fcstTime.localeCompare(b.fcstTime);
+  });
+};
+

--- a/types.ts
+++ b/types.ts
@@ -4,6 +4,11 @@ export interface Coordinates {
   longitude: number;
 }
 
+export interface GridCoordinates {
+  nx: number;
+  ny: number;
+}
+
 export interface LocationSelection {
   city?: string | null;
   coordinates?: Coordinates | null;
@@ -20,4 +25,34 @@ export interface SignalData {
   isMaskOn: boolean;
   isVentilateOn: boolean;
   isHumidifyOn: boolean;
+}
+
+export type PrecipitationTypeCode = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+export const PRECIPITATION_TYPE_LABELS: Record<PrecipitationTypeCode, string> = {
+  0: '없음',
+  1: '비',
+  2: '비/눈',
+  3: '눈',
+  4: '소나기',
+  5: '빗방울',
+  6: '빗방울/눈날림',
+  7: '눈날림',
+};
+
+export type SkyConditionCode = 1 | 3 | 4;
+
+export const SKY_CONDITION_LABELS: Record<SkyConditionCode, string> = {
+  1: '맑음',
+  3: '구름 많음',
+  4: '흐림',
+};
+
+export interface ForecastRow {
+  fcstDate: string;
+  fcstTime: string;
+  temperature: number;
+  precipitationProbability: number;
+  precipitationType: PrecipitationTypeCode;
+  skyCondition: SkyConditionCode;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,8 @@ export default defineConfig(({ mode }) => {
       plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY),
+        'process.env.KMA_SERVICE_KEY': JSON.stringify(env.KMA_SERVICE_KEY),
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- add a KMA Vilage forecast service with grid conversion helpers and typed parsing for TMP/POP/PTY/SKY
- request village forecast data alongside air-quality fetches and surface it in the main screen forecast table
- document the new KMA service key requirement and provide an `.env.local.example` template

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcec721bf88328aa96869ac383bc64