### PR TITLE
feat: show local overview with nationwide summary

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -179,10 +179,12 @@ const App: React.FC = () => {
     : activeLocationLabel
       ? `${activeLocationLabel} · 전국 요약`
       : '대한민국 대기질 요약';
+  const isActiveNationwide = activeLocationQuery === NATIONWIDE_QUERY;
 
   return (
     <MainScreen
       locationName={headerLocationName}
+      activeAirData={activeAirData}
       nationwideData={nationwideData}
       coordinates={coordinates}
       forecastRows={forecastRows}
@@ -193,6 +195,7 @@ const App: React.FC = () => {
       onRefresh={handleRefresh}
       onRequestLocation={handleRequestLocation}
       isLocating={isLocating}
+      isActiveNationwide={isActiveNationwide}
     />
   );
 };

--- a/components/MainScreen.tsx
+++ b/components/MainScreen.tsx
@@ -11,6 +11,7 @@ import ForecastTable from './ForecastTable';
 interface MainScreenProps {
   locationName: string;
   coordinates: Coordinates | null;
+  activeAirData: RawAirData | null;
   nationwideData: RawAirData | null;
   forecastRows: ForecastRow[];
   signalData: SignalData | null;
@@ -20,11 +21,13 @@ interface MainScreenProps {
   onRefresh: () => void;
   onRequestLocation: () => void;
   isLocating: boolean;
+  isActiveNationwide: boolean;
 }
 
 const MainScreen: React.FC<MainScreenProps> = ({
   locationName,
   coordinates,
+  activeAirData,
   nationwideData,
   forecastRows,
   signalData,
@@ -34,6 +37,7 @@ const MainScreen: React.FC<MainScreenProps> = ({
   onRefresh,
   onRequestLocation,
   isLocating,
+  isActiveNationwide,
 }) => {
     
   const timeAgo = useMemo(() => {
@@ -120,6 +124,12 @@ const MainScreen: React.FC<MainScreenProps> = ({
   }, [signalData]);
 
   const effectiveMapExpanded = isDesktop || isMapExpanded;
+  const primaryData = isActiveNationwide ? nationwideData : activeAirData;
+  const primaryVariant = isActiveNationwide ? 'nationwide' : 'local';
+  const primaryFallbackLocation = isActiveNationwide ? '대한민국 주요 지역' : locationName;
+  const primaryLoading = isLoading && (isActiveNationwide || !primaryData);
+  const primaryError = !primaryData ? error : null;
+  const showNationwideComparison = !isActiveNationwide && Boolean(nationwideData);
 
   return (
     <div
@@ -127,12 +137,31 @@ const MainScreen: React.FC<MainScreenProps> = ({
     >
       <Header locationName={locationName} onRefresh={onRefresh} />
       <main className="relative z-10 flex-grow flex flex-col items-center w-full gap-6 px-4 sm:px-6 pt-6 pb-36 sm:pb-12">
-        <div className="w-full max-w-4xl">
+        <div className="w-full max-w-4xl flex flex-col gap-6">
           <div className="group relative overflow-hidden rounded-[2.5rem] border border-white/30 bg-white/20 backdrop-blur-3xl shadow-[0_25px_70px_-30px_rgba(18,40,76,0.65)] transition-all duration-500 hover:-translate-y-1 hover:shadow-[0_35px_90px_-30px_rgba(18,40,76,0.7)]">
             <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-white/30 via-white/10 to-white/5 opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
             <div className="pointer-events-none absolute inset-px rounded-[2.45rem] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.15)]" />
-            <NationwideOverview data={nationwideData} isLoading={isLoading} error={error} />
+            <NationwideOverview
+              variant={primaryVariant}
+              data={primaryData}
+              isLoading={primaryLoading}
+              error={primaryError}
+              fallbackLocationName={primaryFallbackLocation}
+            />
           </div>
+          {showNationwideComparison && nationwideData && (
+            <div className="group relative overflow-hidden rounded-[2.5rem] border border-white/30 bg-white/10 backdrop-blur-3xl shadow-[0_20px_60px_-30px_rgba(18,40,76,0.55)]">
+              <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-white/25 via-white/10 to-white/5 opacity-0 transition-opacity duration-500 group-hover:opacity-100" />
+              <div className="pointer-events-none absolute inset-px rounded-[2.45rem] shadow-[inset_0_0_0_1px_rgba(255,255,255,0.12)]" />
+              <NationwideOverview
+                variant="nationwide"
+                data={nationwideData}
+                isLoading={false}
+                error={null}
+                fallbackLocationName="대한민국 주요 지역"
+              />
+            </div>
+          )}
         </div>
         <div className="w-full max-w-2xl">
           <div

--- a/components/Onboarding.tsx
+++ b/components/Onboarding.tsx
@@ -6,29 +6,59 @@ interface NationwideOverviewProps {
   data: RawAirData | null;
   isLoading: boolean;
   error: string | null;
+  variant?: 'nationwide' | 'local';
+  fallbackLocationName?: string;
 }
 
-const NationwideOverview: React.FC<NationwideOverviewProps> = ({ data, isLoading, error }) => {
+const NationwideOverview: React.FC<NationwideOverviewProps> = ({
+  data,
+  isLoading,
+  error,
+  variant = 'nationwide',
+  fallbackLocationName,
+}) => {
+  const isNationwide = variant === 'nationwide';
+  const locationLabel = data?.locationName ?? fallbackLocationName ?? (isNationwide ? '대한민국 주요 지역' : '현재 위치');
+  const title = isNationwide
+    ? '대한민국 대기질 한눈에 보기'
+    : `${locationLabel} 대기질 한눈에 보기`;
+  const description = isNationwide
+    ? '전국 주요 지역의 대기질을 요약해 실내 생활 신호를 안내해드려요.'
+    : '현재 위치 대기질을 바탕으로 실내 생활 신호를 안내해드려요.';
+  const helperMessages = isNationwide
+    ? ['실시간 데이터를 기반으로 신호가 구성돼요.', '변화가 느껴지면 새로고침해 최신 정보를 확인하세요.']
+    : ['실내 공기질 관리를 위해 현재 위치 데이터를 살펴보세요.', '변화가 느껴지면 새로고침해 최신 정보를 확인하세요.'];
+  const loadingMessage = isNationwide ? '전국 데이터를 불러오는 중...' : '현재 위치 데이터를 불러오는 중...';
+  const emptyMessage = isNationwide
+    ? '대기질 정보를 준비하고 있어요.'
+    : '현재 위치의 대기질 정보를 준비하고 있어요.';
+  const errorTitle = isNationwide ? '전국 데이터를 불러오지 못했습니다.' : '현재 위치 데이터를 불러오지 못했습니다.';
+
   const renderContent = () => {
     if (isLoading) {
       return (
         <div className="flex flex-col items-center justify-center gap-3 py-8">
           <div className="h-12 w-12 border-4 border-primary border-t-transparent rounded-full animate-spin" aria-hidden />
-          <p className="text-base text-ink-muted">전국 데이터를 불러오는 중...</p>
+          <p className="text-base text-ink-muted">{loadingMessage}</p>
         </div>
       );
     }
 
     if (error) {
-      return <p className="text-base font-medium text-danger text-center">{error}</p>;
+      return (
+        <div className="flex flex-col items-center justify-center gap-2 py-6 text-center">
+          <p className="text-base font-semibold text-danger">{errorTitle}</p>
+          <p className="text-sm text-ink-muted">{error}</p>
+        </div>
+      );
     }
 
     if (data) {
       const stats = [
         {
           key: 'location',
-          label: '주요 지역',
-          value: data.locationName,
+          label: isNationwide ? '주요 지역' : '측정 위치',
+          value: locationLabel,
           valueClass: 'text-2xl font-semibold text-ink-strong',
           wrapperClass: '',
         },
@@ -72,7 +102,7 @@ const NationwideOverview: React.FC<NationwideOverviewProps> = ({ data, isLoading
       );
     }
 
-    return <p className="text-base text-ink-muted text-center">대기질 정보를 준비하고 있어요.</p>;
+    return <p className="text-base text-ink-muted text-center">{emptyMessage}</p>;
   };
 
   return (
@@ -84,15 +114,14 @@ const NationwideOverview: React.FC<NationwideOverviewProps> = ({ data, isLoading
             <LogoIcon className="relative z-10 h-10 w-10 text-white drop-shadow-[0_6px_10px_rgba(9,103,255,0.45)]" />
           </div>
           <div>
-            <h2 className="text-2xl sm:text-3xl font-bold text-ink-strong">대한민국 대기질 한눈에 보기</h2>
-            <p className="text-ink-muted text-base sm:text-lg">
-              전국 주요 지역의 대기질을 요약해 실내 생활 신호를 안내해드려요.
-            </p>
+            <h2 className="text-2xl sm:text-3xl font-bold text-ink-strong">{title}</h2>
+            <p className="text-ink-muted text-base sm:text-lg">{description}</p>
           </div>
         </div>
         <div className="text-sm text-ink-muted sm:text-right">
-          <p>실시간 데이터를 기반으로 신호가 구성돼요.</p>
-          <p>변화가 느껴지면 새로고침해 최신 정보를 확인하세요.</p>
+          {helperMessages.map((message) => (
+            <p key={message}>{message}</p>
+          ))}
         </div>
       </div>
       {renderContent()}


### PR DESCRIPTION
## Summary
- pass the active air-quality payload and nationwide flag from App into MainScreen
- render a primary overview card that switches between local and nationwide data and keep a secondary nationwide summary when applicable
- extend NationwideOverview to support variant-specific copy, loading, and error states

## Testing
- npm run build
- npx tsc --noEmit *(fails: missing leaflet image module declarations and strict baseTime typing in services/kmaForecast.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68dcf45f6b0c83289590fa07860282f5