### PR TITLE
fix: handle encoded air quality service key safely

### DIFF
--- a/env.d.ts
+++ b/env.d.ts
@@ -1,0 +1,8 @@
+interface ImportMetaEnv {
+  readonly VITE_AIRKOREA_SERVICE_KEY?: string;
+  readonly VITE_KMA_SERVICE_KEY?: string;
+}
+
+declare interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       "devDependencies": {
         "@types/node": "^22.14.0",
         "@vitejs/plugin-react": "^5.0.0",
+        "tsx": "^4.19.2",
         "typescript": "~5.8.2",
         "vite": "^6.2.0"
       }
@@ -1411,6 +1412,19 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1587,6 +1601,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.52.3",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.3.tgz",
@@ -1670,6 +1694,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.6",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.6.tgz",
+      "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "lint": "tsc --noEmit",
+    "test": "tsx tests/airQualityService.test.ts"
   },
   "dependencies": {
     "@types/leaflet": "^1.9.20",
@@ -18,6 +20,7 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "tsx": "^4.19.2",
     "typescript": "~5.8.2",
     "vite": "^6.2.0"
   }

--- a/services/airQualityService.ts
+++ b/services/airQualityService.ts
@@ -110,14 +110,21 @@ const selectBestItem = (items: AirQualityItem[], location: string): AirQualityIt
 };
 
 export const getAirQualityData = async (location: string): Promise<RawAirData> => {
-  const serviceKey =
+  const rawServiceKey =
     process.env.AIRKOREA_SERVICE_KEY ??
     process.env.KMA_SERVICE_KEY ??
     import.meta.env.VITE_AIRKOREA_SERVICE_KEY ??
     import.meta.env.VITE_KMA_SERVICE_KEY;
 
-  if (!serviceKey) {
+  if (!rawServiceKey) {
     throw new Error('대기질 API 서비스 키가 설정되지 않았습니다.');
+  }
+
+  let serviceKey = rawServiceKey;
+  try {
+    serviceKey = decodeURIComponent(rawServiceKey);
+  } catch {
+    serviceKey = rawServiceKey;
   }
 
   const sidoName = resolveSidoName(location);

--- a/services/kmaForecast.ts
+++ b/services/kmaForecast.ts
@@ -50,7 +50,7 @@ export const latestBaseDateTime = (now: Date = new Date()) => {
   const current = kst.getHours() * 100 + kst.getMinutes();
 
   let baseDate = `${year}${month}${day}`;
-  let baseTime = BASE_TIMES[0];
+  let baseTime: (typeof BASE_TIMES)[number] = BASE_TIMES[0];
 
   for (const time of BASE_TIMES) {
     const baseValue = Number(time);

--- a/tests/airQualityService.test.ts
+++ b/tests/airQualityService.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { getAirQualityData } from '../services/airQualityService';
+
+type FetchCall = { url: string };
+
+const stubResponsePayload = {
+  response: {
+    header: { resultCode: '00' },
+    body: {
+      items: [
+        {
+          stationName: '서울',
+          pm10Value: '12',
+          pm25Value: '8',
+          humidity: '55',
+        },
+      ],
+    },
+  },
+};
+
+const calls: FetchCall[] = [];
+
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = (async (input: RequestInfo | URL) => {
+  const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+  calls.push({ url });
+  return new Response(JSON.stringify(stubResponsePayload), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}) as typeof fetch;
+
+async function run(): Promise<void> {
+  const encodedKey = encodeURIComponent('encoded-service-key');
+  process.env.AIRKOREA_SERVICE_KEY = encodedKey;
+
+  const result = await getAirQualityData('서울특별시 중구');
+
+  assert.equal(result.pm10, 12);
+  assert.equal(result.pm25, 8);
+  assert.equal(result.humidity, 55);
+  assert.equal(result.locationName, '서울');
+
+  assert.equal(calls.length, 1, 'fetch should be called exactly once');
+  const requestUrl = new URL(calls[0]?.url ?? '');
+  assert.equal(requestUrl.searchParams.get('serviceKey'), 'encoded-service-key');
+
+  console.log('Encoded service key test passed.');
+}
+
+run()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    if (originalFetch) {
+      globalThis.fetch = originalFetch;
+    }
+    delete process.env.AIRKOREA_SERVICE_KEY;
+  });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,11 @@
     },
     "allowImportingTsExtensions": true,
     "noEmit": true
-  }
+  },
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "env.d.ts",
+    "types/**/*.d.ts"
+  ]
 }

--- a/types/leaflet-images.d.ts
+++ b/types/leaflet-images.d.ts
@@ -1,0 +1,14 @@
+declare module 'leaflet/dist/images/marker-icon-2x.png' {
+  const value: string;
+  export default value;
+}
+
+declare module 'leaflet/dist/images/marker-icon.png' {
+  const value: string;
+  export default value;
+}
+
+declare module 'leaflet/dist/images/marker-shadow.png' {
+  const value: string;
+  export default value;
+}


### PR DESCRIPTION
## Summary
- decode the air quality service key once with a safe fallback before creating request parameters
- add a lightweight tsx-based test double to confirm encoded keys are accepted and the fetch URL uses the decoded value
- wire up lint/test npm scripts and ambient type declarations so the new test run and tsc succeed under bundler resolution

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68de181566688328a76cb955d0dc4eba