### PR TITLE
Add example environment template for Gemini API key

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,4 @@
+# Gemini API credentials
+# This placeholder feeds the Gemini client in services/geminiService.ts.
+# Copy this file to .env.local and paste your actual Gemini API key below.
+GEMINI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ View your app in AI Studio: https://ai.studio/apps/drive/127IEIc4eg4TQB7G3pPbMCI
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Copy `.env.local.example` to `.env.local` and set the `GEMINI_API_KEY` to your Gemini API key
 3. Run the app:
    `npm run dev`
 


### PR DESCRIPTION
## Summary
- add a `.env.local.example` template that documents the Gemini API key required by the Gemini client
- update the run locally instructions to reference copying the example file when configuring `GEMINI_API_KEY`

## Testing
- not run (docs-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68de25d0516c8328af34f0eded7cc239